### PR TITLE
Update hosts; `enableDevEnvironment`

### DIFF
--- a/Snapyr/Classes/SnapyrHTTPClient.h
+++ b/Snapyr/Classes/SnapyrHTTPClient.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * const kSnapyrAPIBaseHost;
+extern NSString * const kSnapyrAPIBaseHostDev;
 
 
 NS_SWIFT_NAME(HTTPClient)

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -3,11 +3,11 @@
 #import "SnapyrSDKUtils.h"
 #import "SnapyrUtils.h"
 
-#define SNAPYR_CDN_BASE [NSURL URLWithString:@"https://dev-api.snapyr.com/sdk"]
+#define SNAPYR_CDN_BASE [NSURL URLWithString:@"https://dev-api.snapyrdev.net/sdk"]
 
 static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
-NSString * const kSnapyrAPIBaseHost = @"https://dev-engine.snapyr.com/v1";
+NSString * const kSnapyrAPIBaseHost = @"https://dev-engine.snapyrdev.net/v1";
 
 
 @implementation SnapyrHTTPClient

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -3,11 +3,13 @@
 #import "SnapyrSDKUtils.h"
 #import "SnapyrUtils.h"
 
-#define SNAPYR_CDN_BASE [NSURL URLWithString:@"https://dev-api.snapyrdev.net/sdk"]
+#define SNAPYR_CDN_BASE [NSURL URLWithString:@"https://api.snapyr.com/sdk"]
+#define SNAPYR_CDN_BASE_DEV [NSURL URLWithString:@"https://dev-api.snapyrdev.net/sdk"]
 
 static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
-NSString * const kSnapyrAPIBaseHost = @"https://dev-engine.snapyrdev.net/v1";
+NSString * const kSnapyrAPIBaseHost = @"https://engine.snapyr.com/v1";
+NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
 
 
 @implementation SnapyrHTTPClient
@@ -81,7 +83,7 @@ NSString * const kSnapyrAPIBaseHost = @"https://dev-engine.snapyrdev.net/v1";
     //    batch = snapyrCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
     
-    NSURL *url = [[SnapyrUtils getAPIHostURL] URLByAppendingPathComponent:@"batch"];
+    NSURL *url = [[SnapyrUtils getAPIHostURL:self.configuration.enableDevEnvironment] URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
     
     // This is a workaround for an IOS 8.3 bug that causes Content-Type to be incorrectly set
@@ -161,7 +163,13 @@ NSString * const kSnapyrAPIBaseHost = @"https://dev-engine.snapyrdev.net/v1";
 {
     
     NSURLSession *session = self.genericSession;
-    NSURL *url = [SNAPYR_CDN_BASE URLByAppendingPathComponent:[NSString stringWithFormat:@"/%@", writeKey]];
+    NSURL *urlBase;
+    if (self.configuration.enableDevEnvironment) {
+        urlBase = SNAPYR_CDN_BASE_DEV;
+    } else {
+        urlBase = SNAPYR_CDN_BASE;
+    }
+    NSURL *url = [urlBase URLByAppendingPathComponent:[NSString stringWithFormat:@"/%@", writeKey]];
     NSMutableURLRequest *request = self.requestFactory(url);
     NSDictionary *meta = @{ @"defaults": @"true" };
     NSDictionary *defaultSettings = @{ @"metadata" : meta};

--- a/Snapyr/Classes/SnapyrSDKConfiguration.h
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.h
@@ -85,6 +85,13 @@ NS_SWIFT_NAME(SnapyrConfiguration)
 @property (nonatomic, copy, readonly, nullable) NSURL *apiHost;
 
 /**
+ * Whether to use dev endpoints for API config and engine. `NO` by default.
+ * If `NO`, uses production endpoints (`api.snapyr.com` and `engine.snapyr.com`)
+ * If `YES`, uses dev endpoints (`api.snapyrdev.net` and `dev-engine.snapyrdev.net`)
+ */
+@property (nonatomic, assign) BOOL enableDevEnvironment;
+
+/**
  * Whether the sdk should use location services.
  * If `YES` and the host app hasn't asked for permission to use location services then the user will be presented with an alert view asking to do so. `NO` by default.
  * If `YES`, please make sure to add a description for `NSLocationAlwaysUsageDescription` in your `Info.plist` explaining why your app is accessing Location APIs.

--- a/Snapyr/Classes/SnapyrSDKConfiguration.m
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.m
@@ -66,13 +66,14 @@
         self.writeKey = writeKey;
         DLog(@"SnapyrSDKConfiguration.initWithWriteKey");
         // get the host we have stored
-        NSString *host = [SnapyrUtils getAPIHost];
+        NSString *host = [SnapyrUtils getAPIHost:self.enableDevEnvironment];
         if ([host isEqualToString:kSnapyrAPIBaseHost]) {
             // we're getting the generic host back.  have they
             // supplied something other than that?
             if (defaultAPIHost && ![host isEqualToString:defaultAPIHost.absoluteString]) {
                 // we should use the supplied default.
                 host = defaultAPIHost.absoluteString;
+                DLog(@"SnapyrSDKConfiguration init: host: [%@]", host);
                 [SnapyrUtils saveAPIHost:host];
             }
         }
@@ -85,6 +86,7 @@
     if (self = [super init]) {
         self.experimental = [[SnapyrSDKExperimental alloc] init];
         self.shouldUseLocationServices = NO;
+        self.enableDevEnvironment = NO;
         self.enableAdvertisingTracking = YES;
         self.shouldUseBluetooth = NO;
         self.flushAt = 20;
@@ -109,7 +111,7 @@
 
 - (NSURL *)apiHost
 {
-    return [SnapyrUtils getAPIHostURL];
+    return [SnapyrUtils getAPIHostURL:self.enableDevEnvironment];
 }
 
 - (void)use:(id<SnapyrIntegrationFactory>)factory

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -17,7 +17,9 @@ NS_SWIFT_NAME(Utilities)
 
 + (void)saveAPIHost:(nonnull NSString *)apiHost;
 + (nonnull NSString *)getAPIHost;
++ (nonnull NSString *)getAPIHost:(BOOL)enableDevEnvironment;
 + (nullable NSURL *)getAPIHostURL;
++ (nullable NSURL *)getAPIHostURL:(BOOL)enableDevEnvironment;
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist;
 + (id _Nullable)plistFromData:(NSData *)data;

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -32,14 +32,19 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     [defaults setObject:apiHost forKey:[snapyr_apiHost copy]];
 }
 
-+ (nonnull NSString *)getAPIHost
++ (nonnull NSString *)getAPIHost:(BOOL) enableDevEnvironment
 {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *result = [defaults stringForKey:[snapyr_apiHost copy]];
     if (!result) {
-        result = kSnapyrAPIBaseHost;
+        result = (enableDevEnvironment) ? kSnapyrAPIBaseHostDev : kSnapyrAPIBaseHost;
     }
     return result;
+}
+
++ (nonnull NSString *)getAPIHost
+{
+    return [SnapyrUtils getAPIHost:NO];
 }
 
 //+ (nonnull NSString *)getAPIHost
@@ -47,9 +52,14 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
 //    return kSnapyrAPIBaseHost;
 //}
 
++ (nullable NSURL *)getAPIHostURL:(BOOL) enableDevEnvironment
+{
+    return [NSURL URLWithString:[SnapyrUtils getAPIHost:enableDevEnvironment]];
+}
+
 + (nullable NSURL *)getAPIHostURL
 {
-    return [NSURL URLWithString:[SnapyrUtils getAPIHost]];
+    return [SnapyrUtils getAPIHostURL:NO];
 }
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist

--- a/SnapyrTests/SnapyrTestUtils.swift
+++ b/SnapyrTests/SnapyrTestUtils.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 
 struct TestVariables {
-    static var apiHost = "dev-engine.snapyrdev.net"
+    static var apiHost = "engine.snapyr.com"
 }
 
 func failOnError (code: Int, message: String, data: Optional<Data>) {

--- a/SnapyrTests/SnapyrTestUtils.swift
+++ b/SnapyrTests/SnapyrTestUtils.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 
 struct TestVariables {
-    static var apiHost = "dev-engine.snapyr.com"
+    static var apiHost = "dev-engine.snapyrdev.net"
 }
 
 func failOnError (code: Int, message: String, data: Optional<Data>) {

--- a/SnapyrTests/SnapyrTests.swift
+++ b/SnapyrTests/SnapyrTests.swift
@@ -24,7 +24,7 @@ class SnapyrTests: XCTestCase {
         "integrations": [
             "Snapyr": [
                 "apiKey": "QUI5ydwIGeFFTa1IvCBUhxL9PyW5B0jE",
-                "apiHost": "engine.snapyr.com/v1"
+                "apiHost": "dev-engine.snapyrdev.net/v1"
             ]
         ],
         "plan": ["track": [:]],


### PR DESCRIPTION
Update host URLs and add `enableDevEnvironment` flag, consistent w/ other SDKs.

Default => `*.snapyr.com`
enableDevEnvironment => `dev-*.snapyrdev.net`