### PR TITLE
Import unity compatibility

### DIFF
--- a/Snapyr/Classes/Snapyr.h
+++ b/Snapyr/Classes/Snapyr.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 //! Project version number for Analytics.
 FOUNDATION_EXPORT double SnapyrVersionNumber;

--- a/Snapyr/Classes/SnapyrAliasPayload.h
+++ b/Snapyr/Classes/SnapyrAliasPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrPayload.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrContext.h
+++ b/Snapyr/Classes/SnapyrContext.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIntegration.h"
 
 typedef NS_ENUM(NSInteger, SnapyrEventType) {

--- a/Snapyr/Classes/SnapyrCrypto.h
+++ b/Snapyr/Classes/SnapyrCrypto.h
@@ -5,7 +5,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @protocol SnapyrCrypto <NSObject>
 

--- a/Snapyr/Classes/SnapyrGroupPayload.h
+++ b/Snapyr/Classes/SnapyrGroupPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrPayload.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrHTTPClient.h
+++ b/Snapyr/Classes/SnapyrHTTPClient.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrSDK.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrIdentifyPayload.h
+++ b/Snapyr/Classes/SnapyrIdentifyPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrPayload.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrIntegration.h
+++ b/Snapyr/Classes/SnapyrIntegration.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIdentifyPayload.h"
 #import "SnapyrTrackPayload.h"
 #import "SnapyrScreenPayload.h"

--- a/Snapyr/Classes/SnapyrIntegrationFactory.h
+++ b/Snapyr/Classes/SnapyrIntegrationFactory.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIntegration.h"
 #import "SnapyrSDK.h"
 

--- a/Snapyr/Classes/SnapyrMiddleware.h
+++ b/Snapyr/Classes/SnapyrMiddleware.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrContext.h"
 
 typedef void (^SnapyrMiddlewareNext)(SnapyrContext *_Nullable newContext);

--- a/Snapyr/Classes/SnapyrPayload.h
+++ b/Snapyr/Classes/SnapyrPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrSerializableValue.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrReachability.h
+++ b/Snapyr/Classes/SnapyrReachability.h
@@ -21,8 +21,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-@import Foundation;
-@import SystemConfiguration;
+#import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
 
 /**
  * Does ARC support GCD objects?

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIntegrationFactory.h"
 #import "SnapyrCrypto.h"
 #import "SnapyrSDKConfiguration.h"

--- a/Snapyr/Classes/SnapyrSDKConfiguration.h
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.h
@@ -6,12 +6,12 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 #endif
 
 NS_SWIFT_NAME(ApplicationProtocol)

--- a/Snapyr/Classes/SnapyrSDKConfiguration.m
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.m
@@ -13,9 +13,9 @@
 #import "SnapyrHTTPClient.h"
 #import "SnapyrUtils.h"
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 #endif
 
 #if TARGET_OS_IPHONE

--- a/Snapyr/Classes/SnapyrSDKUtils.h
+++ b/Snapyr/Classes/SnapyrSDKUtils.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Snapyr/Classes/SnapyrScreenPayload.h
+++ b/Snapyr/Classes/SnapyrScreenPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrPayload.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrScreenReporting.h
+++ b/Snapyr/Classes/SnapyrScreenReporting.h
@@ -1,7 +1,7 @@
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 #endif
 
 #import "SnapyrSerializableValue.h"

--- a/Snapyr/Classes/SnapyrSerializableValue.h
+++ b/Snapyr/Classes/SnapyrSerializableValue.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /*
  Acceptable dictionary values are

--- a/Snapyr/Classes/SnapyrSnapyrIntegration.h
+++ b/Snapyr/Classes/SnapyrSnapyrIntegration.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIntegration.h"
 #import "SnapyrHTTPClient.h"
 #import "SnapyrStorage.h"

--- a/Snapyr/Classes/SnapyrSnapyrIntegration.m
+++ b/Snapyr/Classes/SnapyrSnapyrIntegration.m
@@ -11,7 +11,7 @@
 #import <pthread.h>
 
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 #endif
 
 dispatch_once_t onlyOnce;

--- a/Snapyr/Classes/SnapyrSnapyrIntegrationFactory.h
+++ b/Snapyr/Classes/SnapyrSnapyrIntegrationFactory.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrIntegrationFactory.h"
 #import "SnapyrHTTPClient.h"
 #import "SnapyrStorage.h"

--- a/Snapyr/Classes/SnapyrStorage.h
+++ b/Snapyr/Classes/SnapyrStorage.h
@@ -5,7 +5,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrCrypto.h"
 
 @protocol SnapyrStorage <NSObject>

--- a/Snapyr/Classes/SnapyrTrackPayload.h
+++ b/Snapyr/Classes/SnapyrTrackPayload.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrPayload.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Snapyr/Classes/SnapyrWebhookIntegration.m
+++ b/Snapyr/Classes/SnapyrWebhookIntegration.m
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrWebhookIntegration.h"
 #import "SnapyrHTTPClient.h"
 #import "SnapyrState.h"

--- a/Snapyr/Internal/NSData+SnapyrGZIP.h
+++ b/Snapyr/Internal/NSData+SnapyrGZIP.h
@@ -31,7 +31,7 @@
 //
 
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 extern void *_Nullable snapyr_libzOpen(void);
 

--- a/Snapyr/Internal/NSViewController+SnapyrScreen.h
+++ b/Snapyr/Internal/NSViewController+SnapyrScreen.h
@@ -9,7 +9,7 @@
 #import "SnapyrSerializableValue.h"
 
 #if TARGET_OS_OSX
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 
 @interface NSViewController (SnapyrScreen)
 

--- a/Snapyr/Internal/SnapyrAES256Crypto.h
+++ b/Snapyr/Internal/SnapyrAES256Crypto.h
@@ -5,7 +5,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrCrypto.h"
 
 

--- a/Snapyr/Internal/SnapyrFileStorage.h
+++ b/Snapyr/Internal/SnapyrFileStorage.h
@@ -5,7 +5,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrStorage.h"
 
 

--- a/Snapyr/Internal/SnapyrIntegrationsManager.h
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrMiddleware.h"
 
 /**

--- a/Snapyr/Internal/SnapyrIntegrationsManager.m
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.m
@@ -7,7 +7,7 @@
 //
 
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 #endif
 #import <objc/runtime.h>
 #import "SnapyrSDKUtils.h"

--- a/Snapyr/Internal/SnapyrState.h
+++ b/Snapyr/Internal/SnapyrState.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Snapyr/Internal/SnapyrState.h
+++ b/Snapyr/Internal/SnapyrState.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *anonymousId;
 @property (nonatomic, strong, nullable) NSString *userId;
 @property (nonatomic, strong, nullable) NSDictionary *traits;
+@property (nonatomic, assign) BOOL hasUnregisteredDeviceToken;
 @end
 
 @interface SnapyrPayloadContext: NSObject

--- a/Snapyr/Internal/SnapyrStoreKitTracker.h
+++ b/Snapyr/Internal/SnapyrStoreKitTracker.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 @import StoreKit;
 #import "SnapyrSDK.h"
 

--- a/Snapyr/Internal/SnapyrUserDefaultsStorage.h
+++ b/Snapyr/Internal/SnapyrUserDefaultsStorage.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrStorage.h"
 
 

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -3,7 +3,7 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "SnapyrSDKUtils.h"
 #import "SnapyrSerializableValue.h"
 

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -12,7 +12,8 @@
 #include <sys/sysctl.h>
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-@import CoreTelephony;
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <CoreTelephony/CTCarrier.h>
 static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 #endif
 

--- a/Snapyr/Internal/UIViewController+SnapyrScreen.h
+++ b/Snapyr/Internal/UIViewController+SnapyrScreen.h
@@ -1,7 +1,7 @@
 #import "SnapyrSerializableValue.h"
 
 #if TARGET_OS_IPHONE
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @interface UIViewController (SnapyrScreen)
 

--- a/SnapyrTests/Utils/NSData+SnapyrGUNZIPP.h
+++ b/SnapyrTests/Utils/NSData+SnapyrGUNZIPP.h
@@ -7,7 +7,7 @@
 //
 // https://github.com/nicklockwood/GZIP/blob/master/GZIP/NSData%2BGZIP.m
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 
 @interface NSData (SnapyrGUNZIPP)

--- a/SnapyrTests/Utils/ObjcUtils.h
+++ b/SnapyrTests/Utils/ObjcUtils.h
@@ -6,6 +6,6 @@
 //  Copyright © 2020 Segment. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NSException * _Nullable objc_tryCatch(void (^ _Nonnull block)(void));


### PR DESCRIPTION
Changes all instances of `@import` to `#include`. This addresses build errors when using a Unity build.

TODO: figure out how to change this back (`@import` has some benefits over `#include`, such as improved build performance), and deal with the Unity issues a better way