### PR TITLE
Notif tracking payload

### DIFF
--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -351,12 +351,20 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
 
 - (void)pushNotificationReceived:(NSDictionary *)info
 {
-    [self track:@"snapyr.observation.event.Impression" properties:info];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:2];
+    properties[@"actionToken"] = [info[@"actionToken"] copy];
+    properties[@"deepLinkUrl"] = info[@"deepLinkUrl"];
+    
+    [self track:@"snapyr.observation.event.Impression" properties:properties];
 }
 
 - (void)pushNotificationTapped:(NSDictionary *)info
 {
-    [self track:@"snapyr.observation.event.Behavior" properties:info];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:2];
+    properties[@"actionToken"] = info[@"actionToken"];
+    properties[@"deepLinkUrl"] = info[@"deepLinkUrl"];
+    
+    [self track:@"snapyr.observation.event.Behavior" properties:properties];
 }
 
 

--- a/SnapyrTests/EndToEndTests.swift
+++ b/SnapyrTests/EndToEndTests.swift
@@ -8,6 +8,7 @@ class EndToEndTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.configuration = SnapyrConfiguration(writeKey: "RSLG3AdcWnHBvqxdGvZJ6FtkNAmudjtX")
+        self.configuration.enableDevEnvironment = true
         self.configuration.flushAt = 1
         Snapyr.debug(true)
         self.configuration.errorHandler = failOnError

--- a/SnapyrTests/SnapyrTests.swift
+++ b/SnapyrTests/SnapyrTests.swift
@@ -252,6 +252,7 @@ class SnapyrTests: XCTestCase {
     
     func testRespectsMaxQueueSize() {
         let config = SnapyrConfiguration(writeKey: "RSLG3AdcWnHBvqxdGvZJ6FtkNAmudjtX")
+        config.enableDevEnvironment = true
         let max = 72
         config.maxQueueSize = UInt(max)
         let sdk2 = Snapyr(configuration: config)
@@ -338,7 +339,8 @@ class SnapyrTests: XCTestCase {
         if let data = data {
             sdk.registeredForRemoteNotifications(withDeviceToken: data)
             let deviceTokenString = getStringFrom(token: data)
-            XCTAssertTrue(deviceTokenString == sdk.getDeviceToken())
+            let sdkProvidedToken = sdk.getDeviceToken()
+            XCTAssertEqual(deviceTokenString, sdkProvidedToken)
         } else {
             XCTAssertNotNil(data)
         }


### PR DESCRIPTION
Fix empty payload on push tracking events 

Before, we passed the whole incoming payload (like on Android). But for APNS payloads, there are multi-level JSON structures, which are silently dropped.

This sets a flat payload with just the action token and deep link URL.