### PR TITLE
Action buttons from push templates

### DIFF
--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A352176023AD5825005B07F6 /* SnapyrMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A352175F23AD5825005B07F6 /* SnapyrMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A3B6E29925116B3A00609A13 /* Snapyr.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EADEB85B1DECD080005322DA /* Snapyr.framework */; };
 		A3BECDD024BCE1E3009E2BD3 /* ObjcUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = A3BECDCF24BCE1E3009E2BD3 /* ObjcUtils.m */; };
+		DA142C3B2798B88B0050D26F /* usr in Resources */ = {isa = PBXBuildFile; fileRef = F6B81350264DE26A00B12EFA /* usr */; };
 		EA88A5981DED7608009FB66A /* SnapyrSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SnapyrSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
 		EAA542771EB4035400945DA7 /* TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA542761EB4035400945DA7 /* TrackingTests.swift */; };
@@ -87,7 +88,6 @@
 		F6309C7A265C091A009D8A84 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6B8134C264DE0CC00B12EFA /* libOCMock.a */; };
 		F651DAC8265DF517000F6909 /* sdk.json in Resources */ = {isa = PBXBuildFile; fileRef = F651DAC7265DF517000F6909 /* sdk.json */; };
 		F68AD013264DB3DE00FE6513 /* SnapyrTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68AD012264DB3DE00FE6513 /* SnapyrTestUtils.swift */; };
-		F6B81351264DE26A00B12EFA /* usr in Resources */ = {isa = PBXBuildFile; fileRef = F6B81350264DE26A00B12EFA /* usr */; };
 		F6BDBFA0265C1AEA0029126B /* SnapyrMockHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BDBF9F265C1AEA0029126B /* SnapyrMockHTTPClient.m */; };
 /* End PBXBuildFile section */
 
@@ -513,7 +513,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F6B81351264DE26A00B12EFA /* usr in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -522,6 +521,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F651DAC8265DF517000F6909 /* sdk.json in Resources */,
+				DA142C3B2798B88B0050D26F /* usr in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -756,7 +756,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VALIDATE_WORKSPACE = YES;
@@ -794,7 +794,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_VERSION = 5.0;
 				VALIDATE_WORKSPACE = YES;
 			};

--- a/Snapyr/Classes/SnapyrHTTPClient.h
+++ b/Snapyr/Classes/SnapyrHTTPClient.h
@@ -16,7 +16,6 @@ NS_SWIFT_NAME(HTTPClient)
 @property (nonatomic, weak)  id<NSURLSessionDelegate> httpSessionDelegate;
 
 @property (nonatomic, assign) SnapyrSDKConfiguration *configuration;
-@property (nonatomic, assign) BOOL enableDevEnvironment;
 
 + (SnapyrRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;
@@ -33,7 +32,7 @@ NS_SWIFT_NAME(HTTPClient)
  */
 - (nullable NSURLSessionUploadTask *)upload:(JSON_DICT)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry, NSInteger code, NSData *_Nullable data))completionHandler;
 
-- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable settings))completionHandler;
+- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nonnull settings))completionHandler;
 
 @end
 

--- a/Snapyr/Classes/SnapyrHTTPClient.h
+++ b/Snapyr/Classes/SnapyrHTTPClient.h
@@ -14,13 +14,15 @@ NS_SWIFT_NAME(HTTPClient)
 @property (nonatomic, readonly) NSMutableDictionary<NSString *, NSURLSession *> *sessionsByWriteKey;
 @property (nonatomic, readonly) NSURLSession *genericSession;
 @property (nonatomic, weak)  id<NSURLSessionDelegate> httpSessionDelegate;
+
 @property (nonatomic, assign) SnapyrSDKConfiguration *configuration;
+@property (nonatomic, assign) BOOL enableDevEnvironment;
 
 + (SnapyrRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;
 
 - (instancetype)initWithRequestFactory:(SnapyrRequestFactory _Nullable)requestFactory
-                         configuration: (SnapyrSDKConfiguration* _Nonnull)configuration;
+                         configuration: (SnapyrSDKConfiguration *_Nullable)configuration;
 
 /**
  * This method will convert the dictionary to json, gzip it and upload the data.

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -30,7 +30,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
 
 
 - (instancetype)initWithRequestFactory:(SnapyrRequestFactory)requestFactory
-                         configuration: (SnapyrSDKConfiguration* _Nonnull)configuration
+                         configuration: (SnapyrSDKConfiguration *)configuration
 {
     if (self = [self init]) {
         if (requestFactory == nil) {
@@ -83,7 +83,11 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
     //    batch = snapyrCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
     
-    NSURL *url = [[SnapyrUtils getAPIHostURL:self.configuration.enableDevEnvironment] URLByAppendingPathComponent:@"batch"];
+    BOOL enableDev = NO;
+    if (self.configuration && self.configuration.enableDevEnvironment) {
+        enableDev = YES;
+    }
+    NSURL *url = [[SnapyrUtils getAPIHostURL:enableDev] URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
     
     // This is a workaround for an IOS 8.3 bug that causes Content-Type to be incorrectly set
@@ -145,7 +149,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
             // non-429 4xx response codes. Don't retry.
             SLog(@"Server rejected payload with HTTP code %d.", code);
             completionHandler(NO, code, nil);
-            if (self.configuration.errorHandler != NULL) {
+            if (self.configuration && self.configuration.errorHandler != NULL) {
                 self.configuration.errorHandler(code, @"error in httpclient", data);
             }
             return;

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -84,7 +84,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
     NSURLSession *session = [self sessionForWriteKey:writeKey];
     
     BOOL enableDev = NO;
-    if (self.configuration && self.configuration.enableDevEnvironment) {
+    if (self.configuration.enableDevEnvironment) {
         enableDev = YES;
     }
     NSURL *url = [[SnapyrUtils getAPIHostURL:enableDev] URLByAppendingPathComponent:@"batch"];
@@ -149,7 +149,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
             // non-429 4xx response codes. Don't retry.
             SLog(@"Server rejected payload with HTTP code %d.", code);
             completionHandler(NO, code, nil);
-            if (self.configuration && self.configuration.errorHandler != NULL) {
+            if (self.configuration.errorHandler != NULL) {
                 self.configuration.errorHandler(code, @"error in httpclient", data);
             }
             return;

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -182,7 +182,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
             return;
         }
         NSInteger code = ((NSHTTPURLResponse *)response).statusCode;
-        if (code > 300) {
+        if (code >= 300) {
             DLog(@"SnapyrHTTPClient.settingsForWriteKey: server responded with unexpected HTTP code [%li]", code);
             
             completionHandler(NO, defaultSettings);

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -160,6 +160,8 @@ NS_SWIFT_NAME(Snapyr)
 - (void)continueUserActivity:(NSUserActivity *)activity;
 - (void)openURL:(NSURL *)url options:(NSDictionary *)options;
 
+- (nullable NSURL *)getDeepLinkForActionId:(NSString *)actionId;
+
 /*!
  @method
 

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -46,6 +46,11 @@ NS_SWIFT_NAME(Snapyr)
 + (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
 
 /**
+ * An extension of the above for internal use/testing, allowed dev mode to be enabled (use dev endpoints rather than prod).
+ */
++ (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler devMode:(BOOL)enableDevMode;
+
+/**
  * Enabled/disables debug logging to trace your data going through the SDK.
  *
  * @param showDebugLogs `YES` to enable logging, `NO` otherwise. `NO` by default.

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
 #import "SnapyrIntegrationFactory.h"
 #import "SnapyrCrypto.h"
 #import "SnapyrSDKConfiguration.h"
@@ -33,6 +34,16 @@ NS_SWIFT_NAME(Snapyr)
  */
 + (void)setupWithConfiguration:(SnapyrSDKConfiguration *)configuration;
 
+/**
+ * Handle incoming notification from a notification service extension. Adds category data, and updates template/category config
+ * when necessary.
+ *
+ * @param writeKey the Snapyr write key
+ * @param bestAttemptContent the mutable copy of notifcation content, which will be written to here and passed to callback
+ * @param originalRequest the original notification request received by the extension, used for referencing data on the notification
+ * @param contentHandler the content handler callback from the notification service extension, used to tell the OS that this request is complete.
+ */
++ (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
 /**
  * Enabled/disables debug logging to trace your data going through the SDK.
  *

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -110,6 +110,7 @@ NS_SWIFT_NAME(Snapyr)
 - (void)setPushNotificationToken:(NSString*)token;
 - (void)pushNotificationReceived:(SERIALIZABLE_DICT _Nullable)info;
 - (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info;
+- (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info actionId:(NSString* _Nullable)actionId;
 
 /*!
  @method

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -44,6 +44,7 @@ NS_SWIFT_NAME(Snapyr)
  * @param contentHandler the content handler callback from the notification service extension, used to tell the OS that this request is complete.
  */
 + (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
+
 /**
  * Enabled/disables debug logging to trace your data going through the SDK.
  *

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -50,7 +50,7 @@ static SnapyrSDK *__sharedInstance = nil;
 {
     NSDictionary *snapyrData = originalRequest.content.userInfo[@"snapyr"];
     if (!snapyrData) {
-        DLog(@"SnapyrSDK NotifExt: Not a Snapyr notification (no Snapyr payload) returning.");
+        DLog(@"SnapyrSDK NotifExt: Not a Snapyr notification (no Snapyr payload); returning.");
         contentHandler(bestAttemptContent);
         return;
     }
@@ -416,18 +416,38 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
 
 - (void)pushNotificationReceived:(NSDictionary *)info
 {
-    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:2];
-    properties[@"actionToken"] = [info[@"actionToken"] copy];
-    properties[@"deepLinkUrl"] = info[@"deepLinkUrl"];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    
+    NSDictionary *snapyrData = info[@"snapyr"];
+    if (!snapyrData) {
+        DLog(@"SnapyrSDK pushNotificationReceived: Not a Snapyr notification (no Snapyr payload); returning.");
+        return;
+    }
+    
+    properties[@"actionToken"] = snapyrData[@"actionToken"];
+    properties[@"deepLinkUrl"] = snapyrData[@"deepLinkUrl"];
     
     [self track:@"snapyr.observation.event.Impression" properties:properties];
 }
 
 - (void)pushNotificationTapped:(NSDictionary *)info
 {
-    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:2];
+    [self pushNotificationTapped:info actionId:nil];
+}
+
+- (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info actionId:(NSString* _Nullable)actionId
+{
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    
+    NSDictionary *snapyrData = info[@"snapyr"];
+    if (!snapyrData) {
+        DLog(@"SnapyrSDK pushNotificationTapped: Not a Snapyr notification (no Snapyr payload); returning.");
+        return;
+    }
+    
     properties[@"actionToken"] = info[@"actionToken"];
     properties[@"deepLinkUrl"] = info[@"deepLinkUrl"];
+    properties[@"actionId"] = actionId;
     
     [self track:@"snapyr.observation.event.Behavior" properties:properties];
 }

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -82,7 +82,6 @@ static SnapyrSDK *__sharedInstance = nil;
                         DLog(@"SnapyrSDK NotifExt: Template data found after settings refresh.");
                     }
                     
-//                    bestAttemptContent.categoryIdentifier = payloadTemplate[@"id"];
                     contentHandler(bestAttemptContent);
                 }];
             } else {
@@ -94,7 +93,6 @@ static SnapyrSDK *__sharedInstance = nil;
     } else {
         // Cached template data is up-to-date - no further work to do
         DLog(@"SnapyrSDK NotifExt: Using cached template data.");
-//        bestAttemptContent.categoryIdentifier = payloadTemplate[@"id"];
         contentHandler(bestAttemptContent);
         return;
     }

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -190,7 +190,6 @@ static SnapyrSDK *__sharedInstance = nil;
 #pragma mark -
 
 NSString *const SnapyrVersionKey = @"SnapyrVersionKey";
-NSString *const SnapyrBuildKeyV1 = @"SnapyrBuildKey";
 NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
 
 #if TARGET_OS_IPHONE
@@ -230,17 +229,12 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
     if (!self.oneTimeConfiguration.trackApplicationLifecycleEvents) {
         return;
     }
-    // Previously SnapyrBuildKey was stored an integer. This was incorrect because the CFBundleVersion
-    // can be a string. This migrates SnapyrBuildKey to be stored as a string.
-    NSInteger previousBuildV1 = [[NSUserDefaults standardUserDefaults] integerForKey:SnapyrBuildKeyV1];
-    if (previousBuildV1) {
-        [[NSUserDefaults standardUserDefaults] setObject:[@(previousBuildV1) stringValue] forKey:SnapyrBuildKeyV2];
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:SnapyrBuildKeyV1];
-    }
+    
+    NSUserDefaults *userDefaults = getGroupUserDefaults();
 
-    NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SnapyrVersionKey];
-    NSString *previousBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:SnapyrBuildKeyV2];
-
+    NSString *previousVersion = [userDefaults stringForKey:SnapyrVersionKey];
+    NSString *previousBuildV2 = [userDefaults stringForKey:SnapyrBuildKeyV2];
+    
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 
@@ -276,10 +270,10 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
 #endif
 
 
-    [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SnapyrVersionKey];
-    [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SnapyrBuildKeyV2];
+    [userDefaults setObject:currentVersion forKey:SnapyrVersionKey];
+    [userDefaults setObject:currentBuild forKey:SnapyrBuildKeyV2];
 
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    [userDefaults synchronize];
 }
 
 - (void)_applicationWillEnterForeground

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -43,6 +43,11 @@ static SnapyrSDK *__sharedInstance = nil;
 
 + (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest *_Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler
 {
+    [SnapyrSDK handleNoticationExtensionRequestWithWriteKey:writeKey bestAttemptContent:bestAttemptContent originalRequest:originalRequest contentHandler:contentHandler devMode:NO];
+}
+
++ (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest *_Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler devMode:(BOOL)enableDevMode
+{
     NSDictionary *snapyrData = originalRequest.content.userInfo[@"snapyr"];
     if (!snapyrData) {
         DLog(@"SnapyrSDK NotifExt: Not a Snapyr notification (no Snapyr payload) returning.");
@@ -59,7 +64,9 @@ static SnapyrSDK *__sharedInstance = nil;
     // Always set category id to template ID - if this template has no actions (no category registered) it will simply be ignored
     bestAttemptContent.categoryIdentifier = payloadTemplate[@"id"];
     
-    SnapyrIntegrationsManager *integrationsManager = [[SnapyrIntegrationsManager alloc] initForExtensionWithWriteKey:writeKey];
+    SnapyrSDKConfiguration *oneOffConfig = [SnapyrSDKConfiguration configurationWithWriteKey:writeKey];
+    oneOffConfig.enableDevEnvironment = enableDevMode;
+    SnapyrIntegrationsManager *integrationsManager = [[SnapyrIntegrationsManager alloc] initForExtensionWithConfig:oneOffConfig];
     NSDictionary *cachedTemplate = [integrationsManager getCachedPushDataForTemplateId:payloadTemplate[@"id"]];
     
     if (cachedTemplate == nil || [cachedTemplate[@"modified"] caseInsensitiveCompare:payloadTemplate[@"modified"]] == NSOrderedAscending) {

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -41,6 +41,13 @@ static SnapyrSDK *__sharedInstance = nil;
     });
 }
 
+// Just pass thru to integrationsManager, where the data actually lives
+// TODO: (@paulwsmith) rename/refactor to `getPayloadForActionId`? (support deep link + other payload types like user-defined JSON)
+- (nullable NSURL *)getDeepLinkForActionId:(NSString *)actionId
+{
+    return [self.integrationsManager getDeepLinkForActionId:actionId];
+}
+
 - (instancetype)initWithConfiguration:(SnapyrSDKConfiguration *)configuration
 {
     DLog(@"SnapyrSDK.initWithConfiguration");

--- a/Snapyr/Classes/SnapyrSDKConfiguration.h
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.h
@@ -201,10 +201,12 @@ NS_SWIFT_NAME(SnapyrConfiguration)
  */
 @property (nonatomic, strong, nullable) id<SnapyrEdgeFunctionMiddleware> edgeFunctionMiddleware;
 
-/**
- * Register a factory that can be used to create an integration.
- */
-- (void)use:(id<SnapyrIntegrationFactory> _Nonnull)factory;
+// PS (2021-01-18): commenting this out to hide from public API. We do not currently support user/config endpoint-configurable factories,
+// only built-in SnapyrSnapyrIntegration. See SnapyrIntegrationsManager `initWithSDK`
+///**
+// * Register a factory that can be used to create an integration.
+// */
+//- (void)use:(id<SnapyrIntegrationFactory> _Nonnull)factory;
 
 /**
  * Leave this nil for iOS extensions, otherwise set to UIApplication.sharedApplication.

--- a/Snapyr/Classes/SnapyrSnapyrIntegration.m
+++ b/Snapyr/Classes/SnapyrSnapyrIntegration.m
@@ -91,19 +91,13 @@ NSUInteger const kSnapyrBackgroundTaskInvalid = 0;
 
         [self dispatchBackground:^{
             // Check for previous queue data in NSUserDefaults and remove if present.
-            NSLog(@"PAUL1: 1");
             if ([getGroupUserDefaults() objectForKey:SnapyrQueueKey]) {
-                NSLog(@"PAUL1: 2");
                 [getGroupUserDefaults() removeObjectForKey:SnapyrQueueKey];
-                NSLog(@"PAUL1: 2a");
             }
 #if !TARGET_OS_TV
             // Check for previous track data in NSUserDefaults and remove if present (Traits still exist in NSUserDefaults on tvOS)
-            NSLog(@"PAUL1: 3");
             if ([getGroupUserDefaults() objectForKey:SnapyrTraitsKey]) {
-                NSLog(@"PAUL1: 4");
                 [getGroupUserDefaults() removeObjectForKey:SnapyrTraitsKey];
-                NSLog(@"PAUL1: 4a");
             }
 #endif
         }];

--- a/Snapyr/Classes/SnapyrSnapyrIntegration.m
+++ b/Snapyr/Classes/SnapyrSnapyrIntegration.m
@@ -91,13 +91,19 @@ NSUInteger const kSnapyrBackgroundTaskInvalid = 0;
 
         [self dispatchBackground:^{
             // Check for previous queue data in NSUserDefaults and remove if present.
-            if ([[NSUserDefaults standardUserDefaults] objectForKey:SnapyrQueueKey]) {
-                [[NSUserDefaults standardUserDefaults] removeObjectForKey:SnapyrQueueKey];
+            NSLog(@"PAUL1: 1");
+            if ([getGroupUserDefaults() objectForKey:SnapyrQueueKey]) {
+                NSLog(@"PAUL1: 2");
+                [getGroupUserDefaults() removeObjectForKey:SnapyrQueueKey];
+                NSLog(@"PAUL1: 2a");
             }
 #if !TARGET_OS_TV
             // Check for previous track data in NSUserDefaults and remove if present (Traits still exist in NSUserDefaults on tvOS)
-            if ([[NSUserDefaults standardUserDefaults] objectForKey:SnapyrTraitsKey]) {
-                [[NSUserDefaults standardUserDefaults] removeObjectForKey:SnapyrTraitsKey];
+            NSLog(@"PAUL1: 3");
+            if ([getGroupUserDefaults() objectForKey:SnapyrTraitsKey]) {
+                NSLog(@"PAUL1: 4");
+                [getGroupUserDefaults() removeObjectForKey:SnapyrTraitsKey];
+                NSLog(@"PAUL1: 4a");
             }
 #endif
         }];
@@ -538,7 +544,7 @@ NSUInteger const kSnapyrBackgroundTaskInvalid = 0;
 {
     NSString *result = nil;
 #if TARGET_OS_TV
-    result = [[NSUserDefaults standardUserDefaults] valueForKey:SnapyrUserIdKey];
+    result = [getGroupUserDefaults() valueForKey:SnapyrUserIdKey];
 #else
     result = [self.fileStorage stringForKey:kSnapyrUserIdFilename];
 #endif

--- a/Snapyr/Internal/SnapyrFileStorage.m
+++ b/Snapyr/Internal/SnapyrFileStorage.m
@@ -138,10 +138,10 @@
     NSURL *containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:appGroupID];
     
     if (containerURL) {
-        NSLog(@"PAUL1: applicationSupportDirectoryURL FOUND containerURL: %@", containerURL);
+        DLog(@"SnapyrFileStorage: applicationSupportDirectoryURL found containerURL: %@", containerURL);
         return [containerURL URLByAppendingPathComponent:@"app"];
     } else {
-        NSLog(@"PAUL1: applicationSupportDirectoryURL COULD NOT FIND containerURL: %@", appGroupID);
+        DLog(@"SnapyrFileStorage: applicationSupportDirectoryURL - no containerURL found, falling back to appGroupID: %@", appGroupID);
         // Probably no app group - default to the application support dir for this app
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
         NSString *storagePath = [paths firstObject];
@@ -156,10 +156,10 @@
     NSString *appGroupID = getAppGroupName();
     NSURL *containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:appGroupID];
     if (containerURL) {
-        NSLog(@"PAUL1: cachesDirectoryURL FOUND containerURL: %@", containerURL);
+        DLog(@"SnapyrFileStorage: cachesDirectoryURL found containerURL: %@", containerURL);
         return [containerURL URLByAppendingPathComponent:@"cache"];
     } else {
-        NSLog(@"PAUL1: cachesDirectoryURL COULD NOT FINE containerURL: %@", appGroupID);
+        DLog(@"SnapyrFileStorage: cachesDirectoryURL - no containerURL found, falling back to appGroupID: %@", appGroupID);
         // Probably no app group - default to the cache dir for this app
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         NSString *storagePath = [paths firstObject];

--- a/Snapyr/Internal/SnapyrIntegrationsManager.h
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SnapyrMiddleware.h"
+#import "SnapyrSDKConfiguration.h"
 
 /**
  * Filenames of "Application Support" files where essential data is stored.

--- a/Snapyr/Internal/SnapyrIntegrationsManager.h
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.h
@@ -34,10 +34,13 @@ NS_SWIFT_NAME(IntegrationsManager)
 
 - (nullable NSURL *)getDeepLinkForActionId:(NSString *_Nonnull)actionId;
 - (instancetype _Nonnull)initWithSDK:(SnapyrSDK *_Nonnull)sdk;
+- (instancetype _Nonnull)initForExtensionWithWriteKey:(NSString *_Nonnull)writeKey;
+- (nullable NSDictionary *)getCachedPushDataForTemplateId: (NSString *_Nonnull)templateId;
 
 // @Deprecated - Exposing for backward API compat reasons only
 - (NSString *_Nonnull)getAnonymousId;
-- (void) refreshSettings;
+- (void)refreshSettings;
+- (void)refreshSettingsWithCompletionHandler:(void (^_Nonnull)(BOOL success, JSON_DICT _Nullable settings))completionHandler;
 
 @end
 

--- a/Snapyr/Internal/SnapyrIntegrationsManager.h
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.h
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(IntegrationsManager)
 
 - (nullable NSURL *)getDeepLinkForActionId:(NSString *_Nonnull)actionId;
 - (instancetype _Nonnull)initWithSDK:(SnapyrSDK *_Nonnull)sdk;
-- (instancetype _Nonnull)initForExtensionWithWriteKey:(NSString *_Nonnull)writeKey;
+- (instancetype _Nonnull)initForExtensionWithConfig:(SnapyrSDKConfiguration *_Nonnull)configuration;
 - (nullable NSDictionary *)getCachedPushDataForTemplateId: (NSString *_Nonnull)templateId;
 
 // @Deprecated - Exposing for backward API compat reasons only

--- a/Snapyr/Internal/SnapyrIntegrationsManager.h
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.h
@@ -32,6 +32,7 @@ NS_SWIFT_NAME(IntegrationsManager)
 // @Deprecated - Exposing for backward API compat reasons only
 @property (nonatomic, readonly) NSMutableDictionary *_Nonnull integrations;
 
+- (nullable NSURL *)getDeepLinkForActionId:(NSString *_Nonnull)actionId;
 - (instancetype _Nonnull)initWithSDK:(SnapyrSDK *_Nonnull)sdk;
 
 // @Deprecated - Exposing for backward API compat reasons only

--- a/Snapyr/Internal/SnapyrIntegrationsManager.m
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.m
@@ -107,7 +107,7 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
         self.httpClient = [[SnapyrHTTPClient alloc] initWithRequestFactory:configuration.requestFactory configuration:configuration];
         
         
-        self.userDefaultsStorage = [[SnapyrUserDefaultsStorage alloc] initWithDefaults:[NSUserDefaults standardUserDefaults] namespacePrefix:nil crypto:configuration.crypto];
+        self.userDefaultsStorage = [[SnapyrUserDefaultsStorage alloc] initWithDefaults:getGroupUserDefaults() namespacePrefix:nil crypto:configuration.crypto];
 #if TARGET_OS_TV
         self.fileStorage = [[SnapyrFileStorage alloc] initWithFolder:[SnapyrFileStorage cachesDirectoryURL] crypto:configuration.crypto];
 #else

--- a/Snapyr/Internal/SnapyrIntegrationsManager.m
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.m
@@ -83,9 +83,6 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
 
 @property (nonatomic) BOOL isServiceExtensionInstance;
 
-// If this instance is init'd from extension, there's no SnapyrSDK instance; writeKey will be stored here directly
-@property (nonatomic, strong) NSString *writeKey;
-
 @end
 
 @interface SnapyrSDK ()
@@ -108,7 +105,6 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
         self.isServiceExtensionInstance = NO;
         self.sdk = sdk;
         self.configuration = configuration;
-        self.writeKey = configuration.writeKey;
         self.serialQueue = snapyr_dispatch_queue_create_specific("com.snapyr.sdk", DISPATCH_QUEUE_SERIAL);
         self.messageQueue = [[NSMutableArray alloc] init];
         
@@ -145,11 +141,11 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
     return self;
 }
 
-- (instancetype _Nonnull)initForExtensionWithWriteKey:(NSString *)writeKey
+- (instancetype _Nonnull)initForExtensionWithConfig:(SnapyrSDKConfiguration *)configuration
 {
     if (self = [super init]) {
         self.isServiceExtensionInstance = YES;
-        self.writeKey = writeKey;
+        self.configuration = configuration;
         self.serialQueue = snapyr_dispatch_queue_create_specific("com.snapyr.sdk", DISPATCH_QUEUE_SERIAL);
         // nil request factory builds with default values.
         // TODO: cache config from main app and use here if config wasn't passed in?
@@ -568,7 +564,7 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
         if (self.settingsRequest) {
             return;
         }
-        self.settingsRequest = [self.httpClient settingsForWriteKey:self.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
+        self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
             self.settingsRequest = nil;
             if (success) {
                 [self setCachedSettings:settings];

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -35,6 +35,8 @@ NSString *getDeviceModel(void);
 BOOL getAdTrackingEnabled(SnapyrSDKConfiguration *configuration);
 NSDictionary *getStaticContext(SnapyrSDKConfiguration *configuration, NSString * _Nullable deviceToken);
 NSDictionary *getLiveContext(SnapyrReachability *reachability, NSDictionary * _Nullable referrer, NSDictionary * _Nullable traits);
+NSString* getAppGroupName(void);
+NSUserDefaults* getGroupUserDefaults(void);
 
 NSString *GenerateUUIDString(void);
 

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -29,13 +29,13 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     if (![apiHost containsString:@"https://"]) {
         apiHost = [NSString stringWithFormat:@"https://%@", apiHost];
     }
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = getGroupUserDefaults();
     [defaults setObject:apiHost forKey:[snapyr_apiHost copy]];
 }
 
 + (nonnull NSString *)getAPIHost:(BOOL) enableDevEnvironment
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *defaults = getGroupUserDefaults();
     NSString *result = [defaults stringForKey:[snapyr_apiHost copy]];
     if (!result) {
         result = (enableDevEnvironment) ? kSnapyrAPIBaseHostDev : kSnapyrAPIBaseHost;
@@ -396,6 +396,42 @@ NSDictionary *getLiveContext(SnapyrReachability *reachability, NSDictionary *ref
     }
     
     return [context copy];
+}
+
+NSString* getAppGroupName(void)
+{
+    // https://stackoverflow.com/a/27849695
+    NSBundle *bundle = [NSBundle mainBundle];
+    // Path extension is "appex" for extensions (in the case of notif service extension)
+    // Remove it to get back to the main bundle ID which will be the same as that from the main app
+    if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"]) {
+        // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
+        bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent] URLByDeletingLastPathComponent]];
+    }
+    
+    NSString* bundleID = [bundle bundleIdentifier];
+//    return [NSString stringWithFormat:@"%@.%@.%@", @"group", bundleID, @"snapyr"];
+    return [NSString stringWithFormat:@"%@.%@.%@", @"group", @"snapyr", bundleID];
+}
+
+/**
+ * Get UserDefaults for shared app group, which is used to share data between main app and notification service extension.
+ * If that doesn't work (because there's no app group by the expected name), fall back to standardUserDefaults
+ */
+NSUserDefaults* getGroupUserDefaults(void)
+{
+    NSString *appGroupName = getAppGroupName();
+    
+    @try {
+        NSLog(@"PAUL1: 11: getGroupUserDefaults, appGroupName: %@", appGroupName);
+        id x = [[NSUserDefaults alloc] initWithSuiteName:appGroupName];
+        NSLog(@"PAUL1: 12: getGroupUserDefaults, result: %@", x);
+        return x;
+    }
+    @catch (NSException *exc) {
+        NSLog(@"SNAPYR getGroupUserDefaults error. appGroupName: %@, bundleID: %@", appGroupName, [[NSBundle mainBundle] bundleIdentifier]);
+        return [NSUserDefaults standardUserDefaults];
+    }
 }
 
 

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -414,7 +414,6 @@ NSString* getAppGroupName(void)
     
     NSString* bundleID = [bundle bundleIdentifier];
     return [NSString stringWithFormat:@"%@.%@.%@", @"group", bundleID, @"snapyr"];
-//    return [NSString stringWithFormat:@"%@.%@.%@", @"group", @"snapyr", bundleID];
 }
 
 /**

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -398,6 +398,9 @@ NSDictionary *getLiveContext(SnapyrReachability *reachability, NSDictionary *ref
     return [context copy];
 }
 
+/**
+ * Get the app group name used by Snapyr SDK convention: `group.{bundle ID}.snapyr`, e.g. `group.com.testorg.testapp.snapyr`
+ */
 NSString* getAppGroupName(void)
 {
     // https://stackoverflow.com/a/27849695
@@ -410,8 +413,8 @@ NSString* getAppGroupName(void)
     }
     
     NSString* bundleID = [bundle bundleIdentifier];
-//    return [NSString stringWithFormat:@"%@.%@.%@", @"group", bundleID, @"snapyr"];
-    return [NSString stringWithFormat:@"%@.%@.%@", @"group", @"snapyr", bundleID];
+    return [NSString stringWithFormat:@"%@.%@.%@", @"group", bundleID, @"snapyr"];
+//    return [NSString stringWithFormat:@"%@.%@.%@", @"group", @"snapyr", bundleID];
 }
 
 /**
@@ -423,13 +426,9 @@ NSUserDefaults* getGroupUserDefaults(void)
     NSString *appGroupName = getAppGroupName();
     
     @try {
-        NSLog(@"PAUL1: 11: getGroupUserDefaults, appGroupName: %@", appGroupName);
-        id x = [[NSUserDefaults alloc] initWithSuiteName:appGroupName];
-        NSLog(@"PAUL1: 12: getGroupUserDefaults, result: %@", x);
-        return x;
+        return [[NSUserDefaults alloc] initWithSuiteName:appGroupName];
     }
     @catch (NSException *exc) {
-        NSLog(@"SNAPYR getGroupUserDefaults error. appGroupName: %@, bundleID: %@", appGroupName, [[NSBundle mainBundle] bundleIdentifier]);
         return [NSUserDefaults standardUserDefaults];
     }
 }

--- a/SnapyrTests/Utils/SnapyrMockHTTPClient.m
+++ b/SnapyrTests/Utils/SnapyrMockHTTPClient.m
@@ -30,7 +30,7 @@
 
 
 - (instancetype)initWithRequestFactory:(SnapyrRequestFactory)requestFactory
-                         configuration: (SnapyrSDKConfiguration* _Nonnull)configuration
+                         configuration: (SnapyrSDKConfiguration *)configuration
 {
     return self;
     

--- a/SnapyrTests/Utils/SnapyrMockHTTPClient.m
+++ b/SnapyrTests/Utils/SnapyrMockHTTPClient.m
@@ -41,7 +41,7 @@
     return [OCMockObject mockForClass:[NSURLSessionUploadTask class]];
 }
 
-- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable settings))completionHandler
+- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nonnull settings))completionHandler
 {
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *path = [bundle pathForResource:@"sdk" ofType:@"json"];

--- a/SnapyrTests/Utils/sdk.json
+++ b/SnapyrTests/Utils/sdk.json
@@ -4,31 +4,35 @@
         "workspaceId": "d00f0649-c6a4-475c-8eeb-518ae5f29768"
     },
     "metadata": {
-        "engine": "",
-        "platform": "Android",
+        "engine": "https://dev-engine.snapyrdev.net",
         "channelId": "6e6e8689-b25d-46b3-a924-7682ba7e6d94",
-        "pushCategories": {
-            "TIMER_EXPIRED": {
+        "pushTemplates": [{
+                "id": "691d895d-bac0-4b92-90ba-df88681461bd",
+                "modified": "2022-01-01T00:00:00.000Z",
                 "actions": [{
+                        "id": "22c6d726-42d4-4339-860d-59714d3bcd46",
                         "actionId": "SNOOZE_ACTION",
                         "title": "Snooze",
                         "deepLinkUrl": "http://snooze.com"
                     },
                     {
+                        "id": "06d5b198-a6c0-4df1-a58f-d6ebcad0bc30",
                         "actionId": "STOP_ACTION",
                         "title": "Stop",
                         "deepLinkUrl": "http://stop.com"
                     }
-                ],
-                "GENERAL": {
-                    "actions": [{
-                        "actionId": "SET_TIMER",
-                        "title": "Set Timer",
-                        "deepLinkUrl": "http://set.com"
-                    }]
-
-                }
+                ]
+            },
+            {
+                "id": "0ed69b61-8af2-47ce-ae45-71a3600cc815",
+                "modified": "2022-01-01T00:00:00.000Z",
+                "actions": [{
+                    "id": "60465344-f2fd-4fc0-9de0-8aa15e25ad37",
+                    "actionId": "SET_TIMER",
+                    "title": "Set Timer",
+                    "deepLinkUrl": "http://set.com"
+                }]
             }
-        }
+        ]
     }
 }


### PR DESCRIPTION
Adds push template config setup, and static helper methods to the SDK that can be called from a notification service extension or by main app code when handling notification taps. 

We now return data about all "live" push templates in the SDK config endpoint, including last modified date and action button definitions. These are fetched at SDK bootup, and used to register notification categories with the action buttons set up.

When a push notification is processed, we compare data on the payload to the SDK's cached push template data to check whether we have up-to-date data for this template. If not, we refetch the config data and register push categories on the fly, prior to letting the notification complete processing. This ensures that action buttons will be registered and set up correctly on an incoming push, even if we were originally missing the config data.

This PR also refactors the cache storage (file and UserDefaults) to use shared app group sandbox locations, so that the data can be accessed by both the main app and by the service extension. This is necessary for allowing config data to be read and updated by the service extension. 

The app group needs to be referenced by string (it can't be looked up automatically from the OS). To deal with this, we use a standardized naming convention of `group.{bundle ID}.snapyr`, e.g. `group.com.testorg.testapp.snapyr`. Developers implementing the SDK will need to add an app group matching this name to their main app and service extension. 