### PR TITLE
SNAPYR-5384 & SNAPYR-5383

### DIFF
--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -43,7 +43,23 @@ NS_SWIFT_NAME(Snapyr)
  * @param originalRequest the original notification request received by the extension, used for referencing data on the notification
  * @param contentHandler the content handler callback from the notification service extension, used to tell the OS that this request is complete.
  */
++ (void)handleNoticationExtensionRequestWithBestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
+
+/**
+ * Handle incoming notification from a notification service extension. Adds category data, and updates template/category config
+ * when necessary.
+ *
+ * @param writeKey the Snapyr write key
+ * @param bestAttemptContent the mutable copy of notifcation content, which will be written to here and passed to callback
+ * @param originalRequest the original notification request received by the extension, used for referencing data on the notification
+ * @param contentHandler the content handler callback from the notification service extension, used to tell the OS that this request is complete.
+ */
 + (void)handleNoticationExtensionRequestWithWriteKey:(NSString *)writeKey bestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
+
+/**
+ * An extension of the above for internal use/testing, allowed dev mode to be enabled (use dev endpoints rather than prod).
+ */
++ (void)handleNoticationExtensionRequestWithBestAttemptContent:(UNMutableNotificationContent * _Nonnull)bestAttemptContent originalRequest:(UNNotificationRequest * _Nonnull)originalRequest contentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler devMode:(BOOL)enableDevMode;
 
 /**
  * An extension of the above for internal use/testing, allowed dev mode to be enabled (use dev endpoints rather than prod).

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -77,6 +77,14 @@ static SnapyrSDK *__sharedInstance = nil;
         return;
     }
     
+  
+    __block bool categoryFetchFinished = NO;
+    __block bool imageFetchFinished = NO;
+    void (^tryToComplete)() = ^void {
+        if (categoryFetchFinished && imageFetchFinished) {
+            contentHandler(bestAttemptContent);
+        }
+    };
     
     // Always set category id to template ID - if this template has no actions (no category registered) it will simply be ignored
     bestAttemptContent.categoryIdentifier = payloadTemplate[@"id"];
@@ -105,49 +113,56 @@ static SnapyrSDK *__sharedInstance = nil;
                     } else {
                         DLog(@"SnapyrSDK NotifExt: Template data found after settings refresh.");
                     }
-                    
+                    categoryFetchFinished = YES;
+                    tryToComplete();
                 }];
             } else {
-                DLog(@"SnapyrSDK NotifExt: Failed attempt to refresh template data.");
-                // Nothing further we can do, let the service extension finish processing
+              // Nothing further we can do, let the service extension finish processing
+              DLog(@"SnapyrSDK NotifExt: Failed attempt to refresh template data.");
+              categoryFetchFinished = YES;
+              tryToComplete();
             }
         }];
     } else {
-        // Cached template data is up-to-date - no further work to do
-        DLog(@"SnapyrSDK NotifExt: Using cached template data.");
-        contentHandler(bestAttemptContent);
-        return;
+      // Cached template data is up-to-date - no further work to do
+      DLog(@"SnapyrSDK NotifExt: Using cached template data.");
+      categoryFetchFinished = YES;
+      tryToComplete();
     }
-    NSString *urlPath = snapyrData[@"imageUrl"];
-    if (urlPath) {
-        NSURL *url = [[NSURL alloc] initWithString:urlPath];
-        NSURL *destination = [[[NSURL alloc] initFileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:url.lastPathComponent];
-        
-        NSURLSessionConfiguration *config = NSURLSessionConfiguration.defaultSessionConfiguration;
-        config.timeoutIntervalForRequest = 4;
-        config.timeoutIntervalForResource = 4;
-        
-        NSURLSessionDataTask *task = [[NSURLSession sessionWithConfiguration:config] dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-            if (data == NULL) {
-                DLog(@"SnapyrSDK NotifExt: Could not fetch notification image from URL");
-                contentHandler(bestAttemptContent);
-            } else {
-                @try {
-                    [data writeToURL:destination atomically:false];
-                    // empty attachment lets the system create its own UUID
-                    UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"" URL:destination options:NULL error:NULL];
-                    bestAttemptContent.attachments = @[attachment];
-                    contentHandler(bestAttemptContent);
-                } @catch (NSException *exception) {
-                    DLog(@"SnapyrSDK NotifExt: Exception happened while creating attachment");
-                    contentHandler(bestAttemptContent);
-                }
-            }
-        }];
-        [task resume];
-    } else {
-        contentHandler(bestAttemptContent);
-    }
+  NSString *urlPath = snapyrData[@"imageUrl"];
+  if (urlPath) {
+    NSURL *url = [[NSURL alloc] initWithString:urlPath];
+    NSURL *destination = [[[NSURL alloc] initFileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:url.lastPathComponent];
+    
+    NSURLSessionConfiguration *config = NSURLSessionConfiguration.defaultSessionConfiguration;
+    config.timeoutIntervalForRequest = 4;
+    config.timeoutIntervalForResource = 4;
+    
+    NSURLSessionDataTask *task = [[NSURLSession sessionWithConfiguration:config] dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+      if ((data == NULL) || (error != NULL)) {
+        DLog(@"SnapyrSDK NotifExt: Could not fetch notification image from URL");
+        imageFetchFinished = YES;
+        tryToComplete();
+      } else {
+        @try {
+          [data writeToURL:destination atomically:false];
+          // empty attachment lets the system create its own UUID
+          UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"" URL:destination options:NULL error:NULL];
+          bestAttemptContent.attachments = @[attachment];
+          imageFetchFinished = YES;
+          tryToComplete();
+        } @catch (NSException *exception) {
+          DLog(@"SnapyrSDK NotifExt: Exception happened while creating attachment");
+          imageFetchFinished = YES;
+          tryToComplete();
+        }
+      }
+    }];
+    [task resume];
+  } else {
+    imageFetchFinished = YES;
+    tryToComplete();
+  }
 }
 
 // Just pass thru to integrationsManager, where the data actually lives

--- a/Snapyr/Classes/SnapyrSDKConfiguration.m
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.m
@@ -64,6 +64,7 @@
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
+        [SnapyrUtils setWriteKey:writeKey];
         DLog(@"SnapyrSDKConfiguration.initWithWriteKey");
         // get the host we have stored
         NSString *host = [SnapyrUtils getAPIHost:self.enableDevEnvironment];

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -20,6 +20,7 @@ NS_SWIFT_NAME(Utilities)
 + (nonnull NSString *)getAPIHost:(BOOL)enableDevEnvironment;
 + (nullable NSURL *)getAPIHostURL;
 + (nullable NSURL *)getAPIHostURL:(BOOL)enableDevEnvironment;
++ (void) setWriteKey: (nonnull NSString*)writeKey;
 + (nullable NSString *)getWriteKey;
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist;

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -20,6 +20,7 @@ NS_SWIFT_NAME(Utilities)
 + (nonnull NSString *)getAPIHost:(BOOL)enableDevEnvironment;
 + (nullable NSURL *)getAPIHostURL;
 + (nullable NSURL *)getAPIHostURL:(BOOL)enableDevEnvironment;
++ (nullable NSString *)getWriteKey;
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist;
 + (id _Nullable)plistFromData:(NSData *)data;

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -63,6 +63,11 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     return [SnapyrUtils getAPIHostURL:NO];
 }
 
++ (nullable NSString *)getWriteKey
+{
+    return [NSUserDefaults.standardUserDefaults stringForKey:@"snapyr_write_key"];
+}
+
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist
 {
     NSError *error = nil;

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -18,6 +18,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 #endif
 
 const NSString *snapyr_apiHost = @"snapyr_apihost";
+NSString * const kSnapyrWriteKey = @"snapyr_write_key";
 
 @implementation SnapyrUtils
 
@@ -63,9 +64,14 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     return [SnapyrUtils getAPIHostURL:NO];
 }
 
++ (void) setWriteKey: (nonnull NSString*)writeKey
+{
+    [getGroupUserDefaults() setObject:writeKey forKey:[kSnapyrWriteKey copy]];
+}
+
 + (nullable NSString *)getWriteKey
 {
-    return [NSUserDefaults.standardUserDefaults stringForKey:@"snapyr_write_key"];
+    return [getGroupUserDefaults() stringForKey: [kSnapyrWriteKey copy]];
 }
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist

--- a/SnapyrTests/SnapyrTests.swift
+++ b/SnapyrTests/SnapyrTests.swift
@@ -29,6 +29,24 @@ class SnapyrTests: XCTestCase {
         ],
         "plan": ["track": [:]],
     ] as NSDictionary
+    
+    private func getTestPayload(invalidURL: Bool = false) -> UNNotificationRequest {
+        let c = UNMutableNotificationContent()
+        c.title = "Push #1"
+        c.body = "Tap a button to do awesome stuff now!"
+        c.userInfo = [
+            "snapyr": [
+                "deepLinkUrl": "snapyrrunner://test/reachedAScoreOf/11",
+                "imageUrl": invalidURL ? "https://blah.com" : "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._RI_.jpg",
+                "pushTemplate": [
+                    "id": "0f819332-2c27-4b99-bc87-325cca7b724a",
+                    "modified": "2022-01-21T16:28:40.626Z"
+                ],
+                "actionToken": "abc1234562"
+            ]
+        ]
+        return UNNotificationRequest.init(identifier: "test_id", content: c, trigger: nil)
+    }
     var sdk: Snapyr!
     var testMiddleware: TestMiddleware!
     var testApplication: TestApplication!
@@ -344,6 +362,51 @@ class SnapyrTests: XCTestCase {
         } else {
             XCTAssertNotNil(data)
         }
+    }
+    
+    func testHandleNotificationImageSuccess() {
+        let dummyRequest = getTestPayload()
+        guard let payload = (dummyRequest.content.mutableCopy() as? UNMutableNotificationContent) else { XCTFail("No payload found in dummy request") ; return }
+        let handleNotificationExpectation = expectation(description: "Test Handle Notification Image Success")
+        Snapyr.handleNoticationExtensionRequest(withBestAttempt: payload, originalRequest: dummyRequest, contentHandler: { modifiedContent in
+            guard let imageAttachment = modifiedContent.attachments.first,
+                  let imageData = try? Data(contentsOf: imageAttachment.url) else {
+                      XCTFail("Could not fetch image data")
+                      handleNotificationExpectation.fulfill()
+                      return
+                  }
+            handleNotificationExpectation.fulfill()
+                  
+        }, devMode: true)
+        wait(for: [handleNotificationExpectation], timeout: 5)
+    }
+    
+    func testHandleNotificationImageFailure() {
+        let dummyRequest = getTestPayload(invalidURL: true)
+        guard let payload = (dummyRequest.content.mutableCopy() as? UNMutableNotificationContent) else { XCTFail("No payload found in dummy request") ; return }
+        let handleNotificationExpectation = expectation(description: "Test Handle Notification Image Failure")
+        Snapyr.handleNoticationExtensionRequest(withBestAttempt: payload, originalRequest: dummyRequest, contentHandler: { modifiedContent in
+            guard let imageAttachment = modifiedContent.attachments.first,
+                  let imageData = try? Data(contentsOf: imageAttachment.url) else {
+                      // success, because content Handler is called
+                      handleNotificationExpectation.fulfill()
+                      return
+                  }
+            XCTFail("Image should fail")
+            handleNotificationExpectation.fulfill()
+        }, devMode: true)
+        wait(for: [handleNotificationExpectation], timeout: 5)
+    }
+    
+    func testHandleNotificationImageTimeout() {
+        let dummyRequest = getTestPayload(invalidURL: true)
+        guard let payload = (dummyRequest.content.mutableCopy() as? UNMutableNotificationContent) else { XCTFail("No payload found in dummy request") ; return }
+        let handleNotificationExpectation = expectation(description: "Test Handle Notification Image Timeout")
+        Snapyr.handleNoticationExtensionRequest(withBestAttempt: payload, originalRequest: dummyRequest, contentHandler: { modifiedContent in
+            // success
+            handleNotificationExpectation.fulfill()
+        }, devMode: true)
+        wait(for: [handleNotificationExpectation], timeout: 5)
     }
 }
 


### PR DESCRIPTION
Joint PR for both related
SNAPYR-5384: Have notification handler process images
SNAPYR-5383: Update so that notification handler doesn't require re-passing SDK write key