### PR TITLE
SNAPYR-5383

### DIFF
--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -20,6 +20,7 @@ NS_SWIFT_NAME(Utilities)
 + (nonnull NSString *)getAPIHost:(BOOL)enableDevEnvironment;
 + (nullable NSURL *)getAPIHostURL;
 + (nullable NSURL *)getAPIHostURL:(BOOL)enableDevEnvironment;
++ (nullable NSString *)getWriteKey;
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist;
 + (id _Nullable)plistFromData:(NSData *)data;

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -63,6 +63,11 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     return [SnapyrUtils getAPIHostURL:NO];
 }
 
++ (nullable NSString *)getWriteKey
+{
+    return [NSUserDefaults.standardUserDefaults stringForKey:@"snapyr_write_key"];
+}
+
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist
 {
     NSError *error = nil;


### PR DESCRIPTION
SNAPYR-5383: Update so that notification handler doesn't require re-passing SDK write key