### PR TITLE
Use `SnapyrEnvironment` enum instead of `enableDevEnvironment` bool

### DIFF
--- a/Snapyr/Classes/SnapyrHTTPClient.h
+++ b/Snapyr/Classes/SnapyrHTTPClient.h
@@ -5,6 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * const kSnapyrAPIBaseHost;
 extern NSString * const kSnapyrAPIBaseHostDev;
+extern NSString * const kSnapyrAPIBaseHostStage;
 
 
 NS_SWIFT_NAME(HTTPClient)

--- a/Snapyr/Classes/SnapyrHTTPClient.m
+++ b/Snapyr/Classes/SnapyrHTTPClient.m
@@ -5,11 +5,13 @@
 
 #define SNAPYR_CDN_BASE [NSURL URLWithString:@"https://api.snapyr.com/sdk"]
 #define SNAPYR_CDN_BASE_DEV [NSURL URLWithString:@"https://dev-api.snapyrdev.net/sdk"]
+#define SNAPYR_CDN_BASE_STAGE [NSURL URLWithString:@"https://stage-api.snapyrdev.net/sdk"]
 
 static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
 NSString * const kSnapyrAPIBaseHost = @"https://engine.snapyr.com/v1";
 NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
+NSString * const kSnapyrAPIBaseHostStage = @"https://stage-engine.snapyrdev.net/v1";
 
 
 @implementation SnapyrHTTPClient
@@ -83,7 +85,7 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
     //    batch = snapyrCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
     
-    NSURL *url = [[SnapyrUtils getAPIHostURL:self.configuration.enableDevEnvironment] URLByAppendingPathComponent:@"batch"];
+    NSURL *url = [[SnapyrUtils getAPIHostURL:self.configuration.snapyrEnvironment] URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
     
     // This is a workaround for an IOS 8.3 bug that causes Content-Type to be incorrectly set
@@ -164,10 +166,19 @@ NSString * const kSnapyrAPIBaseHostDev = @"https://dev-engine.snapyrdev.net/v1";
     
     NSURLSession *session = self.genericSession;
     NSURL *urlBase;
-    if (self.configuration.enableDevEnvironment) {
-        urlBase = SNAPYR_CDN_BASE_DEV;
-    } else {
-        urlBase = SNAPYR_CDN_BASE;
+    switch (self.configuration.snapyrEnvironment) {
+        case SnapyrEnvironmentDev: {
+            urlBase = SNAPYR_CDN_BASE_DEV;
+            break;
+        }
+        case SnapyrEnvironmentStage: {
+            urlBase = SNAPYR_CDN_BASE_STAGE;
+            break;
+        }
+        case SnapyrEnvironmentDefault:
+        default: {
+            urlBase = SNAPYR_CDN_BASE;
+        }
     }
     NSURL *url = [urlBase URLByAppendingPathComponent:[NSString stringWithFormat:@"/%@", writeKey]];
     NSMutableURLRequest *request = self.requestFactory(url);

--- a/Snapyr/Classes/SnapyrSDKConfiguration.h
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SnapyrUtils.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -88,8 +89,12 @@ NS_SWIFT_NAME(SnapyrConfiguration)
  * Whether to use dev endpoints for API config and engine. `NO` by default.
  * If `NO`, uses production endpoints (`api.snapyr.com` and `engine.snapyr.com`)
  * If `YES`, uses dev endpoints (`api.snapyrdev.net` and `dev-engine.snapyrdev.net`)
+ *
+ * This is deprecated. Use `snapyrEnvironment` instead.
  */
-@property (nonatomic, assign) BOOL enableDevEnvironment;
+@property (nonatomic, assign) BOOL enableDevEnvironment DEPRECATED_MSG_ATTRIBUTE("Use .snapyrEnvironment instead.");
+
+@property (nonatomic, assign) SnapyrEnvironment snapyrEnvironment;
 
 /**
  * Whether the sdk should use location services.

--- a/Snapyr/Classes/SnapyrSDKConfiguration.m
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.m
@@ -66,7 +66,7 @@
         self.writeKey = writeKey;
         DLog(@"SnapyrSDKConfiguration.initWithWriteKey");
         // get the host we have stored
-        NSString *host = [SnapyrUtils getAPIHost:self.enableDevEnvironment];
+        NSString *host = [SnapyrUtils getAPIHost:self.snapyrEnvironment];
         if ([host isEqualToString:kSnapyrAPIBaseHost]) {
             // we're getting the generic host back.  have they
             // supplied something other than that?
@@ -87,6 +87,7 @@
         self.experimental = [[SnapyrSDKExperimental alloc] init];
         self.shouldUseLocationServices = NO;
         self.enableDevEnvironment = NO;
+        self.snapyrEnvironment = SnapyrEnvironmentDefault;
         self.enableAdvertisingTracking = YES;
         self.shouldUseBluetooth = NO;
         self.flushAt = 20;
@@ -111,7 +112,7 @@
 
 - (NSURL *)apiHost
 {
-    return [SnapyrUtils getAPIHostURL:self.enableDevEnvironment];
+    return [SnapyrUtils getAPIHostURL:self.snapyrEnvironment];
 }
 
 - (void)use:(id<SnapyrIntegrationFactory>)factory

--- a/Snapyr/Internal/SnapyrUtils.h
+++ b/Snapyr/Internal/SnapyrUtils.h
@@ -12,14 +12,20 @@ NS_ASSUME_NONNULL_BEGIN
 @class SnapyrSDKConfiguration;
 @class SnapyrReachability;
 
+typedef NS_ENUM(NSInteger, SnapyrEnvironment) {
+    SnapyrEnvironmentDefault,
+    SnapyrEnvironmentStage,
+    SnapyrEnvironmentDev
+} NS_SWIFT_NAME(SnapyrEnvironment);
+
 NS_SWIFT_NAME(Utilities)
 @interface SnapyrUtils : NSObject
 
 + (void)saveAPIHost:(nonnull NSString *)apiHost;
 + (nonnull NSString *)getAPIHost;
-+ (nonnull NSString *)getAPIHost:(BOOL)enableDevEnvironment;
++ (nonnull NSString *)getAPIHost:(SnapyrEnvironment)snapyrEnvironment;
 + (nullable NSURL *)getAPIHostURL;
-+ (nullable NSURL *)getAPIHostURL:(BOOL)enableDevEnvironment;
++ (nullable NSURL *)getAPIHostURL:(SnapyrEnvironment)snapyrEnvironment;
 
 + (NSData *_Nullable)dataFromPlist:(nonnull id)plist;
 + (id _Nullable)plistFromData:(NSData *)data;
@@ -84,6 +90,5 @@ NSString *snapyrEventNameForScreenTitle(NSString *title);
 
 @interface NSArray(SerializableDeepCopy) <SnapyrSerializableDeepCopy>
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/Snapyr/Internal/SnapyrUtils.m
+++ b/Snapyr/Internal/SnapyrUtils.m
@@ -33,12 +33,25 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
     [defaults setObject:apiHost forKey:[snapyr_apiHost copy]];
 }
 
-+ (nonnull NSString *)getAPIHost:(BOOL) enableDevEnvironment
++ (nonnull NSString *)getAPIHost:(SnapyrEnvironment) snapyrEnvironment
 {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *result = [defaults stringForKey:[snapyr_apiHost copy]];
     if (!result) {
-        result = (enableDevEnvironment) ? kSnapyrAPIBaseHostDev : kSnapyrAPIBaseHost;
+        switch (snapyrEnvironment) {
+            case SnapyrEnvironmentDev: {
+                result = kSnapyrAPIBaseHostDev;
+                break;
+            }
+            case SnapyrEnvironmentStage: {
+                result = kSnapyrAPIBaseHostStage;
+                break;
+            }
+            case SnapyrEnvironmentDefault:
+            default: {
+                result = kSnapyrAPIBaseHost;
+            }
+        }
     }
     return result;
 }
@@ -53,9 +66,9 @@ const NSString *snapyr_apiHost = @"snapyr_apihost";
 //    return kSnapyrAPIBaseHost;
 //}
 
-+ (nullable NSURL *)getAPIHostURL:(BOOL) enableDevEnvironment
++ (nullable NSURL *)getAPIHostURL:(SnapyrEnvironment) snapyrEnvironment
 {
-    return [NSURL URLWithString:[SnapyrUtils getAPIHost:enableDevEnvironment]];
+    return [NSURL URLWithString:[SnapyrUtils getAPIHost:snapyrEnvironment]];
 }
 
 + (nullable NSURL *)getAPIHostURL

--- a/SnapyrTests/EndToEndTests.swift
+++ b/SnapyrTests/EndToEndTests.swift
@@ -8,7 +8,7 @@ class EndToEndTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.configuration = SnapyrConfiguration(writeKey: "RSLG3AdcWnHBvqxdGvZJ6FtkNAmudjtX")
-        self.configuration.enableDevEnvironment = true
+        self.configuration.snapyrEnvironment = SnapyrEnvironment.dev
         self.configuration.flushAt = 1
         Snapyr.debug(true)
         self.configuration.errorHandler = failOnError

--- a/SnapyrTests/SnapyrTests.swift
+++ b/SnapyrTests/SnapyrTests.swift
@@ -252,7 +252,7 @@ class SnapyrTests: XCTestCase {
     
     func testRespectsMaxQueueSize() {
         let config = SnapyrConfiguration(writeKey: "RSLG3AdcWnHBvqxdGvZJ6FtkNAmudjtX")
-        config.enableDevEnvironment = true
+        config.snapyrEnvironment = SnapyrEnvironment.dev
         let max = 72
         config.maxQueueSize = UInt(max)
         let sdk2 = Snapyr(configuration: config)


### PR DESCRIPTION
... and add a stage option. 

Allows SDK to be configured to point at Snapyr stage environment, not just a boolean between dev or prod.