### PR TITLE
SNAP-43: Add missing tests

### DIFF
--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -38,7 +38,6 @@ NS_SWIFT_NAME(Snapyr)
  * Handle incoming notification from a notification service extension. Adds category data, and updates template/category config
  * when necessary.
  *
- * @param writeKey the Snapyr write key
  * @param bestAttemptContent the mutable copy of notifcation content, which will be written to here and passed to callback
  * @param originalRequest the original notification request received by the extension, used for referencing data on the notification
  * @param contentHandler the content handler callback from the notification service extension, used to tell the OS that this request is complete.

--- a/SnapyrTests/Info.plist
+++ b/SnapyrTests/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>test</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/SnapyrTests/SnapyrTestUtils.swift
+++ b/SnapyrTests/SnapyrTestUtils.swift
@@ -44,4 +44,24 @@ func getUnitTestSDK (
     return sdk
 }
 
+func getTestPayload(invalidURL: Bool = false) -> UNNotificationRequest {
+    let c = UNMutableNotificationContent()
+    c.title = "Push #1"
+    c.body = "Tap a button to do awesome stuff now!"
+    c.userInfo = getTestUserInfo(invalidURL: invalidURL)
+    return UNNotificationRequest.init(identifier: "test_id", content: c, trigger: nil)
+}
 
+func getTestUserInfo(invalidURL: Bool = false) -> [String: Any] {
+    return [
+        "snapyr": [
+            "deepLinkUrl": "snapyrrunner://test/reachedAScoreOf/11",
+            "imageUrl": invalidURL ? "https://blah.com" : "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._RI_.jpg",
+            "pushTemplate": [
+                "id": "0f819332-2c27-4b99-bc87-325cca7b724a",
+                "modified": "2022-01-21T16:28:40.626Z"
+            ],
+            "actionToken": "abc1234562"
+        ]
+    ]
+}

--- a/SnapyrTests/Utils/TestUtils.swift
+++ b/SnapyrTests/Utils/TestUtils.swift
@@ -44,6 +44,9 @@ extension Snapyr {
     func test_integrationsManager() -> IntegrationsManager? {
         return self.value(forKey: "integrationsManager") as? IntegrationsManager
     }
+    func test_enabled() -> Bool? {
+        return self.value(forKey: "enabled") as? Bool
+    }
 }
 
 extension IntegrationsManager {
@@ -59,7 +62,9 @@ extension IntegrationsManager {
     func test_setHttpClient(httpClient: HTTPClient) -> Void {
         self.setValue(httpClient, forKey:"httpClient")
     }
-
+    func test_setActionIdMap(_ data: NSMutableDictionary) {
+        self.setValue(data, forKey: "actionIdMap")
+    }
 }
 
 extension SnapyrIntegration {


### PR DESCRIPTION
In `SnapyrSDK` class (`Snapyr` in Swift) the missing methods that weren't have tests that i found were...:

```
- (void)receivedRemoteNotification:(NSDictionary *)userInfo;
- (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error;
- (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
- (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo;
- (void)continueUserActivity:(NSUserActivity *)activity;
- (void)openURL:(NSURL *)url options:(NSDictionary *)options;
- (nullable NSURL *)getDeepLinkForActionId:(NSString *)actionId;
- (void)reset;
- (void)enable;
- (void)disable;
- (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info actionId:(NSString* _Nullable)actionId;
- (void)pushNotificationReceived:(SERIALIZABLE_DICT _Nullable)info;
```

These methods i placed to test case SnapyrTests :

```
- (nullable NSURL *)getDeepLinkForActionId:(NSString *)actionId;
- (void)enable;
- (void)disable;
```

Other methods i included to TrackingTests test case:

```
- (void)receivedRemoteNotification:(NSDictionary *)userInfo;
- (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error;
- (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
- (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo;
- (void)continueUserActivity:(NSUserActivity *)activity;
- (void)openURL:(NSURL *)url options:(NSDictionary *)options;
- (void)reset;
- (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info actionId:(NSString* _Nullable)actionId;
- (void)pushNotificationReceived:(SERIALIZABLE_DICT _Nullable)info;

```
