### PR TITLE
SNAP-1110: set up as XCFramework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ lint:
 carthage:
 	export XCODE_XCCONFIG_FILE=$(PWD)/tmp.xcconfig && carthage build --platform ios --no-skip-current
 
-archive: carthage
-	carthage archive Snapyr
+archive:
+	./buildxcframework.sh
 
 clean-ios:
 	set -o pipefail && xcodebuild $(IOS_XCARGS) -scheme Snapyr clean | xcpretty

--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -729,6 +729,7 @@
 		EADEB8641DECD080005322DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -756,7 +757,8 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VALIDATE_WORKSPACE = YES;
@@ -766,6 +768,7 @@
 		EADEB8651DECD080005322DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -794,7 +797,8 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				VALIDATE_WORKSPACE = YES;
 			};

--- a/buildxcframework.sh
+++ b/buildxcframework.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+echo "Creating directory 'builtframework' where XCFramework will be stored"
+mkdir builtframework
+mkdir builtframework/ .archives
+
+echo "Archiving for iPhone Simulator"
+rm -r builtframework/.archives
+xcodebuild archive \
+ -scheme Snapyr \
+ -archivePath builtframework/.archives/Snapyr-iphonesimulator.xcarchive \
+ -sdk iphonesimulator \
+ SKIP_INSTALL=NO
+
+echo "Archiving for iOS"
+xcodebuild archive \
+ -scheme Snapyr \
+ -archivePath builtframework/.archives/Snapyr-iphoneos.xcarchive \
+ -sdk iphoneos \
+ SKIP_INSTALL=NO
+
+echo "Archiving for macOS"
+xcodebuild archive \
+ -scheme Snapyr \
+ -archivePath builtframework/.archives/Snapyr-macosx.xcarchive \
+ -sdk macosx \
+ SKIP_INSTALL=NO
+
+echo "Archiving for Apple TV Simulator"
+xcodebuild archive \
+ -scheme Snapyr \
+ -archivePath builtframework/.archives/Snapyr-appletvsimulator.xcarchive \
+ -sdk appletvsimulator \
+ SKIP_INSTALL=NO
+
+echo "Archiving for Apple tvOS"
+xcodebuild archive \
+ -scheme Snapyr \
+ -archivePath builtframework/.archives/Snapyr-appletvos.xcarchive \
+ -sdk appletvos \
+ SKIP_INSTALL=NO
+
+echo "Combining frameworks and creating an XCFramework"
+rm -r builtframework/Snapyr.xcframework
+xcodebuild -create-xcframework \
+ -framework builtframework/.archives/Snapyr-iphonesimulator.xcarchive/Products/Library/Frameworks/Snapyr.framework \
+ -framework builtframework/.archives/Snapyr-iphoneos.xcarchive/Products/Library/Frameworks/Snapyr.framework \
+ -framework builtframework/.archives/Snapyr-macosx.xcarchive/Products/Library/Frameworks/Snapyr.framework \
+ -framework builtframework/.archives/Snapyr-appletvsimulator.xcarchive/Products/Library/Frameworks/Snapyr.framework \
+ -framework builtframework/.archives/Snapyr-appletvos.xcarchive/Products/Library/Frameworks/Snapyr.framework \
+ -output builtframework/Snapyr.xcframework
+
+rm -r builtframework/.archives
+
+open builtframework

--- a/buildxcframework.sh
+++ b/buildxcframework.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 echo "Creating directory 'builtframework' where XCFramework will be stored"
-mkdir builtframework
-mkdir builtframework/ .archives
+mkdir builtframework/.archives
+
+rm -r builtframework/Snapyr.xcframework.zip
+rm -r builtframework/Snapyr.xcframework
 
 echo "Archiving for iPhone Simulator"
 rm -r builtframework/.archives
 xcodebuild archive \
+ -quiet \
  -scheme Snapyr \
  -archivePath builtframework/.archives/Snapyr-iphonesimulator.xcarchive \
  -sdk iphonesimulator \
@@ -13,6 +16,7 @@ xcodebuild archive \
 
 echo "Archiving for iOS"
 xcodebuild archive \
+ -quiet \
  -scheme Snapyr \
  -archivePath builtframework/.archives/Snapyr-iphoneos.xcarchive \
  -sdk iphoneos \
@@ -20,6 +24,7 @@ xcodebuild archive \
 
 echo "Archiving for macOS"
 xcodebuild archive \
+ -quiet \
  -scheme Snapyr \
  -archivePath builtframework/.archives/Snapyr-macosx.xcarchive \
  -sdk macosx \
@@ -27,6 +32,7 @@ xcodebuild archive \
 
 echo "Archiving for Apple TV Simulator"
 xcodebuild archive \
+ -quiet \
  -scheme Snapyr \
  -archivePath builtframework/.archives/Snapyr-appletvsimulator.xcarchive \
  -sdk appletvsimulator \
@@ -34,6 +40,7 @@ xcodebuild archive \
 
 echo "Archiving for Apple tvOS"
 xcodebuild archive \
+ -quiet \
  -scheme Snapyr \
  -archivePath builtframework/.archives/Snapyr-appletvos.xcarchive \
  -sdk appletvos \
@@ -48,7 +55,13 @@ xcodebuild -create-xcframework \
  -framework builtframework/.archives/Snapyr-appletvsimulator.xcarchive/Products/Library/Frameworks/Snapyr.framework \
  -framework builtframework/.archives/Snapyr-appletvos.xcarchive/Products/Library/Frameworks/Snapyr.framework \
  -output builtframework/Snapyr.xcframework
+ 
+cd builtframework
 
-rm -r builtframework/.archives
 
-open builtframework
+zip -vr Snapyr.xcframework.zip Snapyr.xcframework/
+
+rm -r .archives
+rm -r builtframework/Snapyr.xcframework
+
+echo "Archive finished"


### PR DESCRIPTION
Seems to be impossible to configure xcodeproject to immediately build xcframework, so I made a script buildxcframework.sh that combines frameworks to xcframework