### PR TITLE
Action buttons open app in foreground

### DIFF
--- a/Snapyr/Internal/SnapyrIntegrationsManager.m
+++ b/Snapyr/Internal/SnapyrIntegrationsManager.m
@@ -544,8 +544,11 @@ NSString *const kSnapyrCachedSettingsFilename = @"sdk.settings.v2.plist";
                 if (actions) {
                     NSMutableArray<UNNotificationAction *> *categoryActions = [NSMutableArray array];
                     for (NSDictionary *actionDef in actions) {
+                        // Hard code option `UNNotificationActionOptionForeground` - makes taps on action buttons
+                        // open the app in the foreground if it wasn't already.
+                        // TODO: make this configurable on Snapyr push template, and check that here?
                         [categoryActions addObject: [UNNotificationAction actionWithIdentifier:actionDef[@"id"]
-                                                                                         title:actionDef[@"title"] options:UNNotificationActionOptionNone]];
+                                                                                         title:actionDef[@"title"] options:UNNotificationActionOptionForeground]];
                     }
                     // Push `categoryIdentifier` will always be set to Snapyr push template ID, to keep referencing simple
                     [notificationCategories addObject: [UNNotificationCategory categoryWithIdentifier:pushTemplate[@"id"] actions:categoryActions intentIdentifiers:@[] options:UNNotificationCategoryOptionNone]];


### PR DESCRIPTION
Hard code option `UNNotificationActionOptionForeground` - makes taps on action buttons open the app in the foreground if it wasn't already.

TODO: make this configurable on Snapyr push template, and check that here