### PR TITLE
Close button fixes merge

### DIFF
--- a/Media.xcassets/Contents.json
+++ b/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Media.xcassets/overlay_close.imageset/Contents.json
+++ b/Media.xcassets/overlay_close.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Overlay close button dark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Media.xcassets/overlay_close.imageset/Overlay close button dark.svg
+++ b/Media.xcassets/overlay_close.imageset/Overlay close button dark.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="13" cy="13" r="13" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 23C18.5228 23 23 18.5228 23 13C23 7.47715 18.5228 3 13 3C7.47715 3 3 7.47715 3 13C3 18.5228 7.47715 23 13 23ZM16.5808 8L17.9808 9.40175L14.4 12.9912L18 16.5982L16.6 18L13 14.393L9.4 18L8 16.5982L11.6 13.0088L8 9.40175L9.4 8L12.9808 11.607L16.5808 8Z" fill="#333333"/>
+</svg>

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
             name: "Snapyr",
             dependencies: [],
             path: "Snapyr/",
-            exclude: ["SwiftSources"],
             sources: ["Classes", "Internal"],
             publicHeadersPath: "Classes",
             cSettings: [

--- a/Snapyr.podspec
+++ b/Snapyr.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name             = "Snapyr"
   s.module_name      = "Snapyr"
   s.authors          = "Snapyr"
-  s.version          = "1.0.1"
+  s.version          = "1.1.0-beta1"
   s.summary          = "The hassle-free way to add Snapyr sdk to your iOS app."
   s.description      = <<-DESC
                        Snapyr for iOS lets you track everything you need to

--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		A3B6E29925116B3A00609A13 /* Snapyr.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EADEB85B1DECD080005322DA /* Snapyr.framework */; };
 		A3BECDD024BCE1E3009E2BD3 /* ObjcUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = A3BECDCF24BCE1E3009E2BD3 /* ObjcUtils.m */; };
 		DA142C3B2798B88B0050D26F /* usr in Resources */ = {isa = PBXBuildFile; fileRef = F6B81350264DE26A00B12EFA /* usr */; };
+		DA4B565F28EBAA74001AE052 /* SnapyrActionViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA4B565E28EBAA74001AE052 /* SnapyrActionViewHandler.h */; };
+		DA4B566328EBF2F5001AE052 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA4B566228EBF2F5001AE052 /* Media.xcassets */; };
 		DA66EF5E28B0111B006C0AE0 /* SnapyrActionProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = DA66EF5C28B0111B006C0AE0 /* SnapyrActionProcessor.m */; };
 		DA66EF5F28B0111B006C0AE0 /* SnapyrActionProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = DA66EF5D28B0111B006C0AE0 /* SnapyrActionProcessor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA909C6D28C8DB1900408FC3 /* SnapyrInAppMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = DA909C6B28C8DB1900408FC3 /* SnapyrInAppMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -144,6 +146,8 @@
 		A352175F23AD5825005B07F6 /* SnapyrMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapyrMacros.h; sourceTree = "<group>"; };
 		A3BECDCE24BCE1E3009E2BD3 /* ObjcUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcUtils.h; sourceTree = "<group>"; };
 		A3BECDCF24BCE1E3009E2BD3 /* ObjcUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcUtils.m; sourceTree = "<group>"; };
+		DA4B565E28EBAA74001AE052 /* SnapyrActionViewHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapyrActionViewHandler.h; sourceTree = "<group>"; };
+		DA4B566228EBF2F5001AE052 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		DA66EF5C28B0111B006C0AE0 /* SnapyrActionProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnapyrActionProcessor.m; sourceTree = "<group>"; };
 		DA66EF5D28B0111B006C0AE0 /* SnapyrActionProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrActionProcessor.h; sourceTree = "<group>"; };
 		DA909C6B28C8DB1900408FC3 /* SnapyrInAppMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrInAppMessage.h; sourceTree = "<group>"; };
@@ -269,6 +273,7 @@
 				DAA6194C28BD67C2006D2523 /* SnapyrActionMessageView.h */,
 				DAA6194E28BD6F4A006D2523 /* SnapyrActionViewController.h */,
 				DAA6195028BD72D0006D2523 /* SnapyrActionViewController.m */,
+				DA4B565E28EBAA74001AE052 /* SnapyrActionViewHandler.h */,
 			);
 			path = SnapyrActions;
 			sourceTree = "<group>";
@@ -276,6 +281,7 @@
 		EADEB8511DECD080005322DA = {
 			isa = PBXGroup;
 			children = (
+				DA4B566228EBF2F5001AE052 /* Media.xcassets */,
 				F6B81350264DE26A00B12EFA /* usr */,
 				EADEB85D1DECD080005322DA /* SDK */,
 				EADEB86B1DECD0EF005322DA /* SDKTests */,
@@ -481,6 +487,7 @@
 				7304B25A27DB3F67008FB718 /* SnapyrNotificationsProxy.h in Headers */,
 				A352176023AD5825005B07F6 /* SnapyrMacros.h in Headers */,
 				EADEB8D21DECD12B005322DA /* SnapyrUserDefaultsStorage.h in Headers */,
+				DA4B565F28EBAA74001AE052 /* SnapyrActionViewHandler.h in Headers */,
 				EADEB8D01DECD12B005322DA /* SnapyrStoreKitTracker.h in Headers */,
 				EADEB8D41DECD12B005322DA /* SnapyrUtils.h in Headers */,
 				EADEB8601DECD080005322DA /* Snapyr.h in Headers */,
@@ -547,7 +554,7 @@
 				TargetAttributes = {
 					EADEB85A1DECD080005322DA = {
 						CreatedOnToolsVersion = 8.1;
-						LastSwiftMigration = 1250;
+						LastSwiftMigration = 1400;
 						ProvisioningStyle = Manual;
 					};
 					EADEB8691DECD0EF005322DA = {
@@ -581,6 +588,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA4B566328EBF2F5001AE052 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -824,7 +832,7 @@
 				INFOPLIST_FILE = Snapyr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "1.1.0-beta1";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -864,7 +872,7 @@
 				INFOPLIST_FILE = Snapyr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "1.1.0-beta1";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.h
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.h
@@ -2,12 +2,15 @@
 
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
+#import "SnapyrActionViewHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SnapyrActionMessageView : UIView <WKNavigationDelegate>
+extern CGFloat const DEFAULT_MARGIN;
 
-- (instancetype _Nonnull)initWithHTML:(NSString *)htmlPayload withMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler;
+@interface SnapyrActionMessageView : UIView <WKNavigationDelegate, WKUIDelegate>
+
+- (instancetype _Nonnull)initWithHTML:(NSString *)htmlPayload withMessageHandler:(id <WKScriptMessageHandler, SnapyrActionViewHandler>)scriptMessageHandler;
 - (void)reportContentHeight:(NSNumber *)height;
 - (void)doCleanup;
 

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
@@ -2,25 +2,30 @@
 #if !TARGET_OS_OSX && !TARGET_OS_TV
 
 #import "SnapyrUtils.h"
+#import "SnapyrActionViewHandler.h"
+#import "SnapyrActionMessageView.h"
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 
+CGFloat const DEFAULT_MARGIN = 20.0;
 
-@interface SnapyrActionMessageView : UIView <WKNavigationDelegate, WKUIDelegate>
+@interface SnapyrActionMessageView ()
 
 @property (strong, nonatomic, nonnull) NSString *htmlPayload;
 @property (strong, nonatomic) WKWebView *wkWebView;
+@property (weak) id <SnapyrActionViewHandler> snapyrVC;
 
 @end
 
 
 @implementation SnapyrActionMessageView
 
-- (instancetype _Nonnull)initWithHTML:(NSString *)htmlPayload withMessageHandler:(id <WKScriptMessageHandler>)messageHandler {
+- (instancetype _Nonnull)initWithHTML:(NSString *)htmlPayload withMessageHandler:(id <WKScriptMessageHandler, SnapyrActionViewHandler>)messageHandler {
     if (self = [super init]) {
         self.translatesAutoresizingMaskIntoConstraints = false;
     
         self.htmlPayload = htmlPayload;
+        self.snapyrVC = messageHandler;
         
         WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
         [configuration.userContentController addScriptMessageHandler:messageHandler name:@"snapyrMessageHandler"];
@@ -49,13 +54,16 @@
     return self;
 }
 
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    [_snapyrVC onWebViewDidFinishNavigation];
+}
 
 - (CGRect)getStartingBounds {
-    CGFloat defaultMargin = 20.0;
     // Full screen in-app modal: webview size is ~ screen size minus margins...
     CGRect bounds = [UIScreen mainScreen].bounds;
-    bounds.size.width -= (2 * defaultMargin);
-    bounds.size.height -= (2 * defaultMargin);
+    bounds.size.width -= (2 * DEFAULT_MARGIN);
+    bounds.size.height -= (2 * DEFAULT_MARGIN);
     
     if (@available(iOS 11.0, *)) {
         UIApplication *sharedApp = getSharedUIApplication();

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionProcessor.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionProcessor.m
@@ -110,7 +110,7 @@
     
     [self dispatchBackground:^{
         NSLog(@"PAUL: dispatchBackground");
-        NSURLSessionUploadTask *markDeliveredRequest = [self.httpClient markActionDelivered:actionToken forUserId:userId forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry, NSInteger code, NSData *_Nullable data) {
+        [self.httpClient markActionDelivered:actionToken forUserId:userId forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry, NSInteger code, NSData *_Nullable data) {
             void (^completion)(void) = ^{
                 if (retry) {
                     completionHandler(NO);
@@ -161,7 +161,7 @@
             // which is probably what the client expects. If they want to do things off the main thread they
             // can do so explicitly within the callback.
             [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-                self.configuration.actionHandler([message getContent]);
+                self.configuration.actionHandler(message);
             }];
         } else {
             SLog(@"action received, but no handler is configured");

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.h
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.h
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SnapyrActionViewController : UIViewController <WKScriptMessageHandler>
+@interface SnapyrActionViewController : UIViewController <WKScriptMessageHandler, SnapyrActionViewHandler>
 
 @property (strong, nonatomic, nonnull) NSString *htmlPayload;
 @property (strong, atomic, nullable) SnapyrActionMessageView *msgView;
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithHtml:(NSString *)htmlPayload;
 - (void)showHtmlMessage;
+- (void)onWebViewDidFinishNavigation;
 
 @end
 

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionViewHandler.h
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionViewHandler.h
@@ -1,0 +1,8 @@
+//
+//  SnapyrActionViewHandler.h
+//  Snapyr
+//
+
+@protocol SnapyrActionViewHandler
+- (void)onWebViewDidFinishNavigation;
+@end

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -833,7 +833,7 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
 {
     // this has to match the actual version, NOT what's in info.plist
     // because Apple only accepts X.X.X as versions in the review process.
-    return @"1.0.1";
+    return @"1.1.0";
 }
 
 #pragma mark - Helpers

--- a/Snapyr/Classes/SnapyrSDKConfiguration.h
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.h
@@ -88,14 +88,9 @@ NS_SWIFT_NAME(SnapyrConfiguration)
 @property (nonatomic, copy, readonly, nullable) NSURL *apiHost;
 
 /**
- * Whether to use dev endpoints for API config and engine. `NO` by default.
- * If `NO`, uses production endpoints (`api.snapyr.com` and `engine.snapyr.com`)
- * If `YES`, uses dev endpoints (`api.snapyrdev.net` and `dev-engine.snapyrdev.net`)
- *
- * This is deprecated. Use `snapyrEnvironment` instead.
+ * Snapyr internal use only: The Snapyr environment to use (engine and configs).
+ * Defaults to production if not set.
  */
-@property (nonatomic, assign) BOOL enableDevEnvironment DEPRECATED_MSG_ATTRIBUTE("Use .snapyrEnvironment instead.");
-
 @property (nonatomic, assign) SnapyrEnvironment snapyrEnvironment;
 
 /**

--- a/Snapyr/Classes/SnapyrSDKConfiguration.m
+++ b/Snapyr/Classes/SnapyrSDKConfiguration.m
@@ -87,7 +87,6 @@
     if (self = [super init]) {
         self.experimental = [[SnapyrSDKExperimental alloc] init];
         self.shouldUseLocationServices = NO;
-        self.enableDevEnvironment = NO;
         self.snapyrEnvironment = SnapyrEnvironmentDefault;
         self.enableAdvertisingTracking = YES;
         self.shouldUseBluetooth = NO;


### PR DESCRIPTION
(dupe of #37 with cleaned up commits)

* Moves the close button to the top right corner
* Adds + uses PDF-ized SVG graphic for close button as Asset Catalog so that Xcode builds automatically handle different display scales at build time
* Falls back to non-graphic "×" character if graphic load fails - useful when developing SDK code embedded directly within a test app
* Updates display timing to animate the webview modal open and prevent a blank white background from momentarily flickering on screen