### PR TITLE
In-app message - name and content access tweaks

### DIFF
--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		DAA6194D28BD67C8006D2523 /* SnapyrActionMessageView.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194C28BD67C2006D2523 /* SnapyrActionMessageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAA6194F28BD6F4A006D2523 /* SnapyrActionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194E28BD6F4A006D2523 /* SnapyrActionViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAA6195128BD72D0006D2523 /* SnapyrActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA6195028BD72D0006D2523 /* SnapyrActionViewController.m */; };
+		DAA69D8328FDBA07003F8712 /* SnapyrInAppContent.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAA69D8428FDBA07003F8712 /* SnapyrInAppContent.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */; };
 		DAD5844A28C8FFE1002DEDCE /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6B8134C264DE0CC00B12EFA /* libOCMock.a */; };
 		EA88A5981DED7608009FB66A /* SnapyrSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SnapyrSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
@@ -156,6 +158,8 @@
 		DAA6194C28BD67C2006D2523 /* SnapyrActionMessageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapyrActionMessageView.h; sourceTree = "<group>"; };
 		DAA6194E28BD6F4A006D2523 /* SnapyrActionViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapyrActionViewController.h; sourceTree = "<group>"; };
 		DAA6195028BD72D0006D2523 /* SnapyrActionViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SnapyrActionViewController.m; sourceTree = "<group>"; };
+		DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrInAppContent.h; sourceTree = "<group>"; };
+		DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnapyrInAppContent.m; sourceTree = "<group>"; };
 		EA88A5971DED7608009FB66A /* SnapyrSerializableValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrSerializableValue.h; sourceTree = "<group>"; };
 		EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareTests.swift; sourceTree = "<group>"; };
 		EAA542761EB4035400945DA7 /* TrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingTests.swift; sourceTree = "<group>"; };
@@ -345,6 +349,8 @@
 		EADEB8751DECD12B005322DA /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */,
+				DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */,
 				DA909C6B28C8DB1900408FC3 /* SnapyrInAppMessage.h */,
 				DA909C6C28C8DB1900408FC3 /* SnapyrInAppMessage.m */,
 				DAA6194928BD6722006D2523 /* SnapyrActions */,
@@ -500,6 +506,7 @@
 				DAA6194F28BD6F4A006D2523 /* SnapyrActionViewController.h in Headers */,
 				EAA5427D1EB42B8C00945DA7 /* SnapyrReachability.h in Headers */,
 				EADEB8C11DECD12B005322DA /* NSData+SnapyrGZIP.h in Headers */,
+				DAA69D8328FDBA07003F8712 /* SnapyrInAppContent.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -619,6 +626,7 @@
 				75FD4202252401B500BC8970 /* SnapyrWebhookIntegration.m in Sources */,
 				EADEB8CC1DECD12B005322DA /* SnapyrSnapyrIntegration.m in Sources */,
 				EADEB8B21DECD12B005322DA /* SnapyrAliasPayload.m in Sources */,
+				DAA69D8428FDBA07003F8712 /* SnapyrInAppContent.m in Sources */,
 				EADEB8BA1DECD12B005322DA /* SnapyrIntegrationsManager.m in Sources */,
 				EADEB8C41DECD12B005322DA /* SnapyrSDKUtils.m in Sources */,
 				EADEB8C61DECD12B005322DA /* SnapyrFileStorage.m in Sources */,

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
@@ -29,7 +29,7 @@
 
 - (void)showHtmlMessage
 {
-    _msgView = [[SnapyrActionMessageView alloc] initWithHTML:_message.rawPayload withMessageHandler:self];
+    _msgView = [[SnapyrActionMessageView alloc] initWithHTML:[_message.content getHtmlPayload] withMessageHandler:self];
     self.view.alpha = 0;
     [self.view addSubview:_msgView];
     // Center the modal both horizontally and vertically
@@ -153,7 +153,6 @@
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     UIImage *buttonImg = [UIImage imageNamed:@"overlay_close" inBundle:bundle compatibleWithTraitCollection:nil];
     if (buttonImg != nil) {
-        CGFloat scaleFactor = buttonSize / buttonImg.size.width;
         [_closeButton setImage:buttonImg forState:UIControlStateNormal];
         _closeButton.imageEdgeInsets = UIEdgeInsetsMake(buttonSize, buttonSize, buttonSize, buttonSize);
     } else {

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
@@ -97,7 +97,7 @@
     } else {
         parameters = [NSDictionary dictionary];
     }
-    [self.sdk trackInAppMessageClickWithActionToken:_message.actionToken withParameters:parameters];
+    [self.sdk trackInAppMessageClickWithActionToken:_message.actionToken withProperties:parameters];
 
     UIApplication *sharedApp = getSharedUIApplication();
     if (sharedApp != nil && [payload[@"url"] isKindOfClass:[NSString class]]) {

--- a/Snapyr/Classes/SnapyrInAppContent.h
+++ b/Snapyr/Classes/SnapyrInAppContent.h
@@ -1,0 +1,19 @@
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, SnapyrInAppPayloadType) {
+    SnapyrInAppPayloadTypeJson,
+    SnapyrInAppPayloadTypeHtml
+} NS_SWIFT_NAME(SnapyrInAppPayloadType);
+
+@interface SnapyrInAppContent : NSObject
+
+@property (readonly) SnapyrInAppPayloadType payloadType;
+
+- (instancetype)initWithRawContent:(NSDictionary * _Nonnull)rawContent;
+- (NSDictionary *)getJsonPayload;
+- (NSString *)getHtmlPayload;
+- (NSDictionary *)asDict;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snapyr/Classes/SnapyrInAppContent.m
+++ b/Snapyr/Classes/SnapyrInAppContent.m
@@ -1,0 +1,84 @@
+#import <Foundation/Foundation.h>
+#import "SnapyrUtils.h"
+#import "SnapyrInAppContent.h"
+#import "SnapyrInAppMessage.h"
+
+
+@interface SnapyrInAppContent ()
+@property (readonly) NSString *rawPayload;
+@property (readonly) NSDictionary *jsonPayload;
+@property (readonly) NSString *htmlPayload;
+@end
+
+
+@implementation SnapyrInAppContent
+
+- (SnapyrInAppContent *) initWithRawContent:(NSDictionary * _Nonnull)rawContent {
+    if (self = [super init]) {
+    
+        NSString *rawPayload = rawContent[@"payload"];
+        if ([rawPayload length] == 0) {
+            @throw [NSException exceptionWithName:@"Bad Initialization"
+                                           reason:@"Missing `content.payload`."
+                                         userInfo:nil];
+        }
+        _rawPayload = [rawPayload copy];
+        
+        NSString *payloadType = rawContent[@"payloadType"];
+        if ([payloadType isEqualToString:kPayloadTypeJson]) {
+            _payloadType = SnapyrInAppPayloadTypeJson;
+            
+            NSError *jsonError = nil;
+            NSData *payloadData = [_rawPayload dataUsingEncoding:NSUTF8StringEncoding];
+            NSDictionary *payloadDict = [NSJSONSerialization JSONObjectWithData:payloadData
+                                                                         options:kNilOptions
+                                                                           error:&jsonError];
+            if (jsonError != nil) {
+                @throw [NSException exceptionWithName:@"Bad Initialization"
+                                               reason:@"`content.payload` could not be parsed as JSON."
+                                             userInfo:nil];
+            }
+            _jsonPayload = payloadDict;
+        } else if ([payloadType isEqualToString:kPayloadTypeHtml]) {
+            _payloadType = SnapyrInAppPayloadTypeHtml;
+            _htmlPayload = _rawPayload;
+        } else {
+            @throw [NSException exceptionWithName:@"Bad Initialization"
+                                           reason:@"Invalid or missing `content.payloadType`."
+                                         userInfo:nil];
+        }
+    }
+    
+    return self;
+}
+
+- (NSDictionary *)getJsonPayload
+{
+    if (_jsonPayload == nil) {
+        @throw [NSException exceptionWithName:@"Incorrect Access"
+                                       reason:@"Content is not json."
+                                     userInfo:nil];
+    }
+    return _jsonPayload;
+}
+
+- (NSString *)getHtmlPayload
+{
+    if (_htmlPayload == nil) {
+        @throw [NSException exceptionWithName:@"Incorrect Access"
+                                       reason:@"Content is not html."
+                                     userInfo:nil];
+    }
+    return _htmlPayload;
+}
+
+- (NSDictionary *)asDict
+{
+    if (_payloadType == SnapyrInAppPayloadTypeJson) {
+        return @{@"payloadType": kPayloadTypeJson, @"payload": _jsonPayload};
+    } else {
+        return @{@"payloadType": kPayloadTypeHtml, @"payload": _htmlPayload};
+    }
+}
+
+@end

--- a/Snapyr/Classes/SnapyrInAppMessage.h
+++ b/Snapyr/Classes/SnapyrInAppMessage.h
@@ -1,29 +1,29 @@
+#import "SnapyrInAppContent.h"
+
 NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const kActionTypeOverlay;
+extern NSString * const kActionTypeCustom;
+extern NSString * const kPayloadTypeJson;
+extern NSString * const kPayloadTypeHtml;
 
 typedef NS_ENUM(NSInteger, SnapyrInAppActionType) {
     SnapyrInAppActionTypeOverlay,
     SnapyrInAppActionTypeCustom
-} NS_SWIFT_NAME(SnapyrInAppActionTypeCustom);
-
-typedef NS_ENUM(NSInteger, SnapyrInAppContentType) {
-    SnapyrInAppContentTypeJson,
-    SnapyrInAppContentTypeHtml
-} NS_SWIFT_NAME(SnapyrInAppContentType);
+} NS_SWIFT_NAME(SnapyrInAppActionType);
 
 @interface SnapyrInAppMessage : NSObject
 
 @property (strong, readonly) NSString *actionToken;
 @property (strong, readonly) NSString *userId;
 @property (readonly) SnapyrInAppActionType actionType;
-@property (readonly) SnapyrInAppContentType contentType;
-@property (strong, readonly) NSString *rawPayload;
+@property (readonly) SnapyrInAppContent *content;
 @property (readonly) NSDate *timestamp;
 
 - (instancetype)initWithActionPayload:(NSDictionary * _Nonnull)rawAction;
 - (BOOL)displaysOverlay;
 - (NSDictionary *)asDict;
 - (NSString *)asJson;
-- (NSDictionary *)getContent;
 
 @end
 

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -146,7 +146,8 @@ NS_SWIFT_NAME(Snapyr)
 - (void)pushNotificationTapped:(SERIALIZABLE_DICT _Nullable)info actionId:(NSString* _Nullable)actionId;
 
 - (void)trackInAppMessageImpressionWithActionToken:(NSString *)actionToken;
-- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken withParameters:(NSDictionary *)parameters;
+- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken;
+- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken withProperties:(NSDictionary *_Nullable)baseProperties;
 - (void)trackInAppMessageDismissWithActionToken:(NSString *)actionToken;
 
 /*!

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -624,9 +624,15 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
     [self track:@"test_impression" properties:properties];
 }
 
-- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken withParameters:(NSDictionary *)parameters
+- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken
 {
-    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:parameters];
+    NSDictionary *properties = [NSDictionary dictionary];
+    [self trackInAppMessageClickWithActionToken:actionToken withProperties:properties];
+}
+
+- (void)trackInAppMessageClickWithActionToken:(NSString *)actionToken withProperties:(NSDictionary *)baseProperties
+{
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:baseProperties];
 
     properties[@"actionToken"] = actionToken;
     properties[@"platform"] = @"ios";


### PR DESCRIPTION
### `SnapyrInAppMessage` - split content into its own class 

Brings the interface for checking in-app messages more in line with that of the Android SDK, which also enforces payload access more strictly by requiring consumer to call the appropriate content getter method depending on whether the payload type is JSON or HTML.

i.e. to get the payload for a JSON message, you now need to call 
```
NSDictionary *json = [message.content getJsonPayload];
``` 
while for an HTML message you need to call 
```
NSString *html = [message.content getHtmlPayload];
```

### Name tweaks
Updates a couple of names to be more consistent with other parts of the system, namely `payloadType` rather than `contentType`.