### PR TITLE
Overlay padding fix

### DIFF
--- a/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
@@ -80,7 +80,7 @@ CGFloat const DEFAULT_MARGIN = 20.0;
 - (void)reportContentHeight:(NSNumber *)height {
     float scaledHeight = [height floatValue] / [UIScreen mainScreen].scale;
     CGRect bounds = _wkWebView.bounds;
-    bounds.size.height = scaledHeight + 8;
+    bounds.size.height = scaledHeight;
     CGRect maximumBounds = [self getStartingBounds];
     if (bounds.size.height > maximumBounds.size.height) {
         return;

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
@@ -29,6 +29,10 @@ CGFloat const DEFAULT_MARGIN = 20.0;
         
         WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
         [configuration.userContentController addScriptMessageHandler:messageHandler name:@"snapyrMessageHandler"];
+        // Allows videos to play within the overlay - without this, playing a video always triggers fullscreen
+        // NB fullscreen video playback from this overlay is buggy - overlay continues to render in front of it.
+        // TODO - fix this when we need to support video playback
+        configuration.allowsInlineMediaPlayback = true;
         
         CGRect bounds = [self getStartingBounds];
         

--- a/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionViewController.m
@@ -41,7 +41,7 @@
     _uiWindow.alpha = 0;
     // Place it in front
     _uiWindow.windowLevel = UIWindowLevelAlert;
-    // 50% transparent black - shadow background
+    // 50% transparent black - modal backdrop
     _uiWindow.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.5];
 
     // Setting self to be window's rootViewController is what attaches our views to the window
@@ -74,8 +74,10 @@
 - (void)finishDisplayingWebView
 {
     [self.view layoutIfNeeded];
+    // Show the window immediately - the backdrop will cover the full screen, then content will animate in
     self.uiWindow.alpha = 1.0;
     [_uiWindow makeKeyAndVisible];
+    // Render the view (actual overlay content plus close button) with a quick scale-up and fade-in transition
     self.view.transform = CGAffineTransformMakeScale(0.7, 0.7);
     [UIView animateWithDuration:0.3f animations:^{
         self.view.transform = CGAffineTransformMakeScale(1.0, 1.0);


### PR DESCRIPTION
Removes extraneous padding at the bottom of in-app overlays.

Also adds a config for inline video playback, but video playback is still buggy / not yet supported.