### PR TITLE
Record build date in Info.plist; helper methods

### DIFF
--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 				EADEB8571DECD080005322DA /* Frameworks */,
 				EADEB8581DECD080005322DA /* Headers */,
 				EADEB8591DECD080005322DA /* Resources */,
+				DAC4B6A02935954E004172BC /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -609,6 +610,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DAC4B6A02935954E004172BC /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Adds current date as a \"build date\" value to Info.plist, which can be read by the SDK at runtime\ninfoplist=\"$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\"\nbuilddate=`date`\nif [[ -n \"$builddate\" ]]; then\n    echo \"Adding SnapyrBuildDate to Info.plist...\"\n    # if it doesn't exist, add it\n    /usr/libexec/PlistBuddy -c \"Add :SnapyrBuildDate date $builddate\" \"${infoplist}\"\n    # if it exists, update it\n    /usr/libexec/PlistBuddy -c \"Set :SnapyrBuildDate $builddate\" \"${infoplist}\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		EADEB8561DECD080005322DA /* Sources */ = {

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -888,6 +888,19 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
     return @"1.1.1";
 }
 
+// Following 2 methods are for internal test use and intentionally excluded from header to make them non-public/non-documented
++ (NSString *)marketingVersion
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    return [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"]; // "Marketing version" in project settings
+}
+
++ (NSDate *)buildDate
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    return [bundle objectForInfoDictionaryKey:@"SnapyrBuildDate"];
+}
+
 #pragma mark - Helpers
 
 - (void)run:(SnapyrEventType)eventType payload:(SnapyrPayload *)payload


### PR DESCRIPTION
Adds hidden/internal-use helper methods to get build info for test apps, and a build script that records the build date to info.plist at build time