### PR TITLE
Fix overlays sometimes showing bottom "border"

### DIFF
--- a/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
+++ b/Snapyr/Classes/SnapyrActions/SnapyrActionMessageView.m
@@ -82,7 +82,8 @@ CGFloat const DEFAULT_MARGIN = 20.0;
 }
 
 - (void)reportContentHeight:(NSNumber *)height {
-    float scaledHeight = [height floatValue] / [UIScreen mainScreen].scale;
+    // Dimensions are typically not whole numbers. Fractional pixel vals can result in an off-color, one-pixel "border" at the bottom of the message - round down to prevent this
+    float scaledHeight = floorf([height floatValue] / [UIScreen mainScreen].scale);
     CGRect bounds = _wkWebView.bounds;
     bounds.size.height = scaledHeight;
     CGRect maximumBounds = [self getStartingBounds];


### PR DESCRIPTION
https://snapyr.atlassian.net/browse/MEKA-641

Overlay/HTML dimensions are typically not whole numbers. Fractional pixel vals can result in an off-color, one-pixel "border" at the bottom of the message. Updates height code to round down to prevent this.

Before:
![Screen Shot 2022-12-06 at 12 10 56 PM](https://user-images.githubusercontent.com/273823/205977591-9687325c-9370-445f-8896-9fe6922ee03e.png)

After: 
![Screen Shot 2022-12-06 at 12 12 27 PM](https://user-images.githubusercontent.com/273823/205977770-db97ecf2-32ec-46bd-8021-c894554c8b63.png)
