### PR TITLE
Push handling updates

### DIFF
--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -34,12 +34,12 @@
 		DA4B565F28EBAA74001AE052 /* SnapyrActionViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA4B565E28EBAA74001AE052 /* SnapyrActionViewHandler.h */; };
 		DA4B566328EBF2F5001AE052 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA4B566228EBF2F5001AE052 /* Media.xcassets */; };
 		DA66EF5E28B0111B006C0AE0 /* SnapyrActionProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = DA66EF5C28B0111B006C0AE0 /* SnapyrActionProcessor.m */; };
-		DA66EF5F28B0111B006C0AE0 /* SnapyrActionProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = DA66EF5D28B0111B006C0AE0 /* SnapyrActionProcessor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA66EF5F28B0111B006C0AE0 /* SnapyrActionProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = DA66EF5D28B0111B006C0AE0 /* SnapyrActionProcessor.h */; };
 		DA909C6D28C8DB1900408FC3 /* SnapyrInAppMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = DA909C6B28C8DB1900408FC3 /* SnapyrInAppMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA909C6E28C8DB1900408FC3 /* SnapyrInAppMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = DA909C6C28C8DB1900408FC3 /* SnapyrInAppMessage.m */; };
 		DAA6194B28BD6780006D2523 /* SnapyrActionMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA6194A28BD6780006D2523 /* SnapyrActionMessageView.m */; };
-		DAA6194D28BD67C8006D2523 /* SnapyrActionMessageView.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194C28BD67C2006D2523 /* SnapyrActionMessageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAA6194F28BD6F4A006D2523 /* SnapyrActionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194E28BD6F4A006D2523 /* SnapyrActionViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAA6194D28BD67C8006D2523 /* SnapyrActionMessageView.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194C28BD67C2006D2523 /* SnapyrActionMessageView.h */; };
+		DAA6194F28BD6F4A006D2523 /* SnapyrActionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA6194E28BD6F4A006D2523 /* SnapyrActionViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DAA6195128BD72D0006D2523 /* SnapyrActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA6195028BD72D0006D2523 /* SnapyrActionViewController.m */; };
 		DAA69D8328FDBA07003F8712 /* SnapyrInAppContent.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAA69D8428FDBA07003F8712 /* SnapyrInAppContent.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */; };

--- a/Snapyr.xcodeproj/project.pbxproj
+++ b/Snapyr.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		DAA69D8328FDBA07003F8712 /* SnapyrInAppContent.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAA69D8428FDBA07003F8712 /* SnapyrInAppContent.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */; };
 		DAD5844A28C8FFE1002DEDCE /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6B8134C264DE0CC00B12EFA /* libOCMock.a */; };
+		DAE398BC294405BB00072EFE /* SnapyrNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE398B82943FB0700072EFE /* SnapyrNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAE398BD294405C100072EFE /* SnapyrNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE398BA2943FB2100072EFE /* SnapyrNotification.m */; };
 		EA88A5981DED7608009FB66A /* SnapyrSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SnapyrSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
 		EAA542771EB4035400945DA7 /* TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA542761EB4035400945DA7 /* TrackingTests.swift */; };
@@ -160,6 +162,8 @@
 		DAA6195028BD72D0006D2523 /* SnapyrActionViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SnapyrActionViewController.m; sourceTree = "<group>"; };
 		DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrInAppContent.h; sourceTree = "<group>"; };
 		DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnapyrInAppContent.m; sourceTree = "<group>"; };
+		DAE398B82943FB0700072EFE /* SnapyrNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrNotification.h; sourceTree = "<group>"; };
+		DAE398BA2943FB2100072EFE /* SnapyrNotification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SnapyrNotification.m; sourceTree = "<group>"; };
 		EA88A5971DED7608009FB66A /* SnapyrSerializableValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrSerializableValue.h; sourceTree = "<group>"; };
 		EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareTests.swift; sourceTree = "<group>"; };
 		EAA542761EB4035400945DA7 /* TrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingTests.swift; sourceTree = "<group>"; };
@@ -282,6 +286,13 @@
 			path = SnapyrActions;
 			sourceTree = "<group>";
 		};
+		DAE398B72943FAE200072EFE /* SnapyrNotifications */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SnapyrNotifications;
+			sourceTree = "<group>";
+		};
 		EADEB8511DECD080005322DA = {
 			isa = PBXGroup;
 			children = (
@@ -349,6 +360,9 @@
 		EADEB8751DECD12B005322DA /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				DAE398B82943FB0700072EFE /* SnapyrNotification.h */,
+				DAE398BA2943FB2100072EFE /* SnapyrNotification.m */,
+				DAE398B72943FAE200072EFE /* SnapyrNotifications */,
 				DAA69D8128FDBA07003F8712 /* SnapyrInAppContent.h */,
 				DAA69D8228FDBA07003F8712 /* SnapyrInAppContent.m */,
 				DA909C6B28C8DB1900408FC3 /* SnapyrInAppMessage.h */,
@@ -502,6 +516,7 @@
 				DA66EF5F28B0111B006C0AE0 /* SnapyrActionProcessor.h in Headers */,
 				630FC8EA2107F2A500A759C5 /* SnapyrScreenReporting.h in Headers */,
 				EADEB8AE1DECD12B005322DA /* SnapyrAES256Crypto.h in Headers */,
+				DAE398BC294405BB00072EFE /* SnapyrNotification.h in Headers */,
 				EADEB8C51DECD12B005322DA /* SnapyrFileStorage.h in Headers */,
 				DAA6194F28BD6F4A006D2523 /* SnapyrActionViewController.h in Headers */,
 				EAA5427D1EB42B8C00945DA7 /* SnapyrReachability.h in Headers */,
@@ -637,6 +652,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE398BD294405C100072EFE /* SnapyrNotification.m in Sources */,
 				EADEB8DD1DECD12B005322DA /* SnapyrSDK.m in Sources */,
 				EADEB8BE1DECD12B005322DA /* SnapyrScreenPayload.m in Sources */,
 				EADEB8B61DECD12B005322DA /* SnapyrIdentifyPayload.m in Sources */,

--- a/Snapyr/Classes/SnapyrLogger.m
+++ b/Snapyr/Classes/SnapyrLogger.m
@@ -86,14 +86,15 @@ SnapyrHTTPClient *httpClient = NULL;
 
 - (nullable NSData*) getLogData
 {
-    NSURL *logFileUrl = [self logFileUrl];
-    if (logFileUrl) {
-        @try {
-            NSData *data = [[NSData alloc] initWithContentsOfURL:logFileUrl];
-        } @catch (NSException *exception) {
-            return NULL;
-        }
-    }
+    // todo: return data when valid and uncomment? (or remove this)
+//    NSURL *logFileUrl = [self logFileUrl];
+//    if (logFileUrl) {
+//        @try {
+//            NSData *data = [[NSData alloc] initWithContentsOfURL:logFileUrl];
+//        } @catch (NSException *exception) {
+//            return NULL;
+//        }
+//    }
     return NULL;
 }
 

--- a/Snapyr/Classes/SnapyrNotification.h
+++ b/Snapyr/Classes/SnapyrNotification.h
@@ -1,0 +1,25 @@
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SnapyrNotification : NSObject
+
+@property (readonly) UInt32 notificationId;
+@property (readonly) NSString *titleText;
+@property (readonly) NSString *contentText;
+@property (readonly) NSString *subtitleText;
+
+@property (readonly) NSString *templateId;
+@property (readonly) NSDate *templateModified;
+
+@property (readonly) NSURL *deepLinkUrl;
+@property (readonly) NSString *imageUrl;
+
+@property (readonly) NSString *actionId;
+@property (readonly) NSString *actionToken;
+
+- (instancetype)initWithNotifUserInfo:(NSDictionary * _Nonnull)userInfo;
+- (NSDictionary *)asDict;
+- (NSString *)asJson;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snapyr/Classes/SnapyrNotification.h
+++ b/Snapyr/Classes/SnapyrNotification.h
@@ -5,15 +5,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) UInt32 notificationId;
 @property (readonly) NSString *titleText;
 @property (readonly) NSString *contentText;
-@property (readonly) NSString *subtitleText;
+@property (readonly, nullable) NSString *subtitleText;
 
-@property (readonly) NSString *templateId;
-@property (readonly) NSDate *templateModified;
+@property (readonly, nullable) NSString *templateId;
+@property (readonly, nullable) NSDate *templateModified;
 
-@property (readonly) NSURL *deepLinkUrl;
-@property (readonly) NSString *imageUrl;
+@property (readonly, nullable) NSURL *deepLinkUrl;
+@property (readonly, nullable) NSString *imageUrl;
 
-@property (readonly) NSString *actionId;
+@property (readonly, nullable) NSString *actionId;
 @property (readonly) NSString *actionToken;
 
 - (instancetype)initWithNotifUserInfo:(NSDictionary * _Nonnull)userInfo;

--- a/Snapyr/Classes/SnapyrNotification.m
+++ b/Snapyr/Classes/SnapyrNotification.m
@@ -1,0 +1,98 @@
+#import <Foundation/Foundation.h>
+#import "SnapyrUtils.h"
+#import "SnapyrNotification.h"
+
+@implementation SnapyrNotification
+
+- (instancetype)initWithNotifUserInfo:(NSDictionary * _Nonnull)userInfo {
+    if (self = [super init]) {
+        
+        // TODO: might want to change this to account for silent/background push notifs in the future
+        NSDictionary *apsAlert = userInfo[@"aps"][@"alert"];
+        if (apsAlert == nil) {
+            @throw [NSException exceptionWithName:@"badInitialization"
+                                           reason:@"Invalid or missing `aps.alert`."
+                                         userInfo:nil];
+        }
+        
+        _titleText = apsAlert[@"title"];
+        _contentText = apsAlert[@"body"];
+        if (_titleText == nil || _contentText == nil) {
+            @throw [NSException exceptionWithName:@"badInitialization"
+                                           reason:@"Invalid message - missing required data."
+                                         userInfo:nil];
+        }
+        _subtitleText = apsAlert[@"subtitle"];
+        
+        NSDictionary *snapyrData = userInfo[@"snapyr"];
+        if (snapyrData == nil) {
+            @throw [NSException exceptionWithName:@"nonSnapyrNotification"
+                                           reason:@"Invalid or missing `snapyr`."
+                                         userInfo:nil];
+        }
+        
+        NSDictionary *template = snapyrData[@"pushTemplate"];
+        if (template != nil) {
+            NSString *templateId = template[@"id"];
+            NSString *rawTimestamp = template[@"modified"];
+            if ([templateId length] > 0 && [rawTimestamp length] > 0) {
+                _templateModified = dateFromIso8601String(rawTimestamp);
+                if (_templateModified != nil) {
+                    _templateId = templateId;
+                }
+            }
+        }
+        
+        _actionId = snapyrData[@"actionId"]; // nullable
+        _actionToken = snapyrData[@"actionToken"];
+        if (_actionToken == nil) {
+            @throw [NSException exceptionWithName:@"badInitialization"
+                                           reason:@"Invalid message - missing actionToken."
+                                         userInfo:nil];
+        }
+        
+        // Unique (enough) integer by hashing action token, which is itself already unique for every notification
+        // This class cannot generate its own ID because iOS doesn't allow us to mutate an existing notification, so a generated ID might be different between e.g. a "receive" and "response" on the same actual notification.
+        // TODO: see if we can have the notification service extension set an ID value, or have back end include it
+        _notificationId = (UInt32)[_actionToken hash];
+        
+        NSString *deepLinkUrl = snapyrData[@"deepLinkUrl"];
+        if ([deepLinkUrl length] > 0) {
+            _deepLinkUrl = [NSURL URLWithString:deepLinkUrl];
+        }
+        
+        _imageUrl = snapyrData[@"imageUrl"];
+        
+    }
+    
+    return self;
+}
+
+- (NSDictionary *)asDict
+{
+    NSDictionary *dict = @{
+        @"notificationId": [NSNumber numberWithUnsignedLong:_notificationId],
+        @"titleText": _titleText,
+        @"contentText": _contentText,
+        // NB dict value can't be literal `nil` (that's equivalent to not having key set). Set nullable fields to special [NSNull null] object so they'll be translated into JSON properly as `{"key": null}`
+        @"subtitleText": _subtitleText ? _subtitleText : [NSNull null],
+        @"deepLinkUrl": _deepLinkUrl ? [_deepLinkUrl absoluteString] : [NSNull null],
+        @"imageUrl": _imageUrl ? _imageUrl : [NSNull null],
+        @"actionToken": _actionToken,
+    };
+    
+    return dict;
+}
+
+- (NSString *)asJson
+{
+    NSDictionary *dict = [self asDict];
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
+                                                       options:NSJSONWritingPrettyPrinted error:&error];
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    
+    return jsonString;
+}
+
+@end

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -88,8 +88,6 @@ NS_SWIFT_NAME(Snapyr)
  */
 + (instancetype)sharedSDK;
 
-+ (void)appDidFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions;
-
 /**
  * Push: call from your App Delegate's `application:didReceiveRemoteNotification:fetchCompletionHandler:` method to wire up push-receive data.
  * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -88,6 +88,29 @@ NS_SWIFT_NAME(Snapyr)
  */
 + (instancetype)sharedSDK;
 
++ (void)appDidFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions;
+
+/**
+ * Push: call from your App Delegate's `application:didReceiveRemoteNotification:fetchCompletionHandler:` method to wire up push-receive data.
+ * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
+ * but can only track message receipt after SDK initialization.
+ */
++ (void)appDidReceiveRemoteNotification:(NSDictionary *)userInfo;
+
+/**
+ * Push: call from your App Delegate's `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` method to wire up push-response data.
+ * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
+ * but can only track message receipt after SDK initialization.
+ */
++ (void)appDidReceiveNotificationResponse:(UNNotificationResponse *)response;
+
+/**
+ * Push: call from your App Delegate's `application:didRegisterForRemoteNotificationsWithDeviceToken:` method to wire up push-response data.
+ * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
+ * but can only track message receipt after SDK initialization.
+ */
++ (void)appRegisteredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+
 /*!
  @method
 

--- a/Snapyr/Classes/SnapyrSDK.h
+++ b/Snapyr/Classes/SnapyrSDK.h
@@ -93,21 +93,21 @@ NS_SWIFT_NAME(Snapyr)
  * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
  * but can only track message receipt after SDK initialization.
  */
-+ (void)appDidReceiveRemoteNotification:(NSDictionary *)userInfo;
++ (void)appDidReceiveRemoteNotification:(NSDictionary *)userInfo API_UNAVAILABLE(tvos);
 
 /**
  * Push: call from your App Delegate's `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` method to wire up push-response data.
  * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
  * but can only track message receipt after SDK initialization.
  */
-+ (void)appDidReceiveNotificationResponse:(UNNotificationResponse *)response;
++ (void)appDidReceiveNotificationResponse:(UNNotificationResponse *)response API_UNAVAILABLE(tvos);
 
 /**
  * Push: call from your App Delegate's `application:didRegisterForRemoteNotificationsWithDeviceToken:` method to wire up push-response data.
  * This is a static (class) method. If it is called before initializing the SDK instance, it will fire off internal events that may be used by consuming SDKs (e.g. React Native),
  * but can only track message receipt after SDK initialization.
  */
-+ (void)appRegisteredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)appRegisteredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken API_UNAVAILABLE(tvos);
 
 /*!
  @method

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -597,21 +597,7 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
         [__sharedInstance pushNotificationTapped:snapyrData];
     }
     
-    // If the notification from the Snapyr campaign has a deep link URL set, the following code will open it.
-    if (snapyrData[@"deepLinkUrl"] != nil) {
-        NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@", snapyrData[@"deepLinkUrl"]]];
-        UIApplication *sharedApp = getSharedUIApplication();
-        if (sharedApp != nil) {
-            if ([sharedApp canOpenURL:url]) {
-                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: opening deepLinkUrl: [%@]", url);
-                [sharedApp openURL:url options:@{} completionHandler:nil];
-            } else {
-                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: unable to open deepLinkUrl (no app matches url scheme?) url: [%@] scheme: [%@]", url, [url scheme]);
-            }
-        } else {
-            DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: found deepLinkUrl, but couldn't get sharedApplication! [%@]", url);
-        }
-    }
+    [self openNotificationDeeplinkUrl:snapyrNotif];
     
     // Notify any listeners for this event, e.g. React Native SDK
     NSString *actionIdentifier = response.actionIdentifier;
@@ -619,6 +605,23 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
      postNotificationName:@"snapyr.didReceiveNotificationResponse"
      object:nil
      userInfo:@{@"actionIdentifier": actionIdentifier, @"snapyrNotification": snapyrNotif}];
+}
+
++ (void)openNotificationDeeplinkUrl:(SnapyrNotification *)snapyrNotif NS_EXTENSION_UNAVAILABLE("Cannot be used from within app extensions.")
+{
+    if (snapyrNotif.deepLinkUrl != nil) {
+        UIApplication *sharedApp = getSharedUIApplication();
+        if (sharedApp != nil) {
+            if ([sharedApp canOpenURL:snapyrNotif.deepLinkUrl]) {
+                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: opening deepLinkUrl: [%@]", snapyrNotif.deepLinkUrl);
+                [sharedApp openURL:snapyrNotif.deepLinkUrl options:@{} completionHandler:nil];
+            } else {
+                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: unable to open deepLinkUrl (no app matches url scheme?) url: [%@] scheme: [%@]", snapyrNotif.deepLinkUrl, [snapyrNotif.deepLinkUrl scheme]);
+            }
+        } else {
+            DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: found deepLinkUrl, but couldn't get sharedApplication! [%@]", snapyrNotif.deepLinkUrl);
+        }
+    }
 }
 
 + (void)appRegisteredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -490,6 +490,7 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
         properties[@"token"] = [SnapyrState sharedInstance].context.deviceToken;
         [self track:@"snapyr.hidden.apnsTokenSet" properties:properties];
         [SnapyrState sharedInstance].userInfo.hasUnregisteredDeviceToken = NO;
+        DLog(@"SnapyrSDK.identify: registered push token: [%@]", [SnapyrState sharedInstance].context.deviceToken);
     }
 }
 
@@ -541,8 +542,10 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
         NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:1];
         properties[@"token"] = token;
         [self track:@"snapyr.hidden.apnsTokenSet" properties:properties];
+        DLog(@"SnapyrSDK.setPushNotificationToken: registered push token: [%@]", token);
     } else {
         [SnapyrState sharedInstance].userInfo.hasUnregisteredDeviceToken = YES;
+        DLog(@"SnapyrSDK.setPushNotificationToken: received push token, but no user yet: [%@]", token);
     }
 }
 

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -63,12 +63,13 @@ static SnapyrSDK *__sharedInstance = nil;
 + (void)setupWithConfiguration:(SnapyrSDKConfiguration *)configuration;
 {
     [SnapyrUtils setConfiguration:configuration];
-	SnapyrNotificationsProxy *proxy = [SnapyrNotificationsProxy sharedProxy];
-	if (configuration.swizzleAppDelegateAndUserNotificationsDelegate) {
-		[proxy swizzleMethodsIfPossible];
-	} else {
-		[proxy unswizzleMethodsIfPossible];
-	}
+    // TODO: fix up swizzling and re-enable
+//	SnapyrNotificationsProxy *proxy = [SnapyrNotificationsProxy sharedProxy];
+//	if (configuration.swizzleAppDelegateAndUserNotificationsDelegate) {
+//		[proxy swizzleMethodsIfPossible];
+//	} else {
+//		[proxy unswizzleMethodsIfPossible];
+//	}
     DLog(@"SnapyrSDK.setupWithConfiguration");
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -596,6 +596,22 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
         [__sharedInstance pushNotificationTapped:snapyrData];
     }
     
+    // If the notification from the Snapyr campaign has a deep link URL set, the following code will open it.
+    if (snapyrData[@"deepLinkUrl"] != nil) {
+        NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@", snapyrData[@"deepLinkUrl"]]];
+        UIApplication *sharedApp = getSharedUIApplication();
+        if (sharedApp != nil) {
+            if ([sharedApp canOpenURL:url]) {
+                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: opening deepLinkUrl: [%@]", url);
+                [sharedApp openURL:url options:@{} completionHandler:nil];
+            } else {
+                DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: unable to open deepLinkUrl (no app matches url scheme?) url: [%@] scheme: [%@]", url, [url scheme]);
+            }
+        } else {
+            DLog(@"SnapyrSDK.appDidReceiveNotificationResponse: ERROR: found deepLinkUrl, but couldn't get sharedApplication! [%@]", url);
+        }
+    }
+    
     // Notify any listeners for this event, e.g. React Native SDK
     NSString *actionIdentifier = response.actionIdentifier;
     [[NSNotificationCenter defaultCenter]

--- a/Snapyr/Classes/SnapyrSDK.m
+++ b/Snapyr/Classes/SnapyrSDK.m
@@ -596,9 +596,9 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
     if (snapyrData) {
         [__sharedInstance pushNotificationTapped:snapyrData];
     }
-    
+#if !TARGET_OS_OSX
     [self openNotificationDeeplinkUrl:snapyrNotif];
-    
+#endif
     // Notify any listeners for this event, e.g. React Native SDK
     NSString *actionIdentifier = response.actionIdentifier;
     [[NSNotificationCenter defaultCenter]
@@ -607,6 +607,7 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
      userInfo:@{@"actionIdentifier": actionIdentifier, @"snapyrNotification": snapyrNotif}];
 }
 
+#if !TARGET_OS_OSX
 + (void)openNotificationDeeplinkUrl:(SnapyrNotification *)snapyrNotif NS_EXTENSION_UNAVAILABLE("Cannot be used from within app extensions.")
 {
     if (snapyrNotif.deepLinkUrl != nil) {
@@ -623,6 +624,7 @@ NSString *const SnapyrBuildKeyV2 = @"SnapyrBuildKeyV2";
         }
     }
 }
+#endif
 
 + (void)appRegisteredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {

--- a/Snapyr/Classes/SnapyrSnapyrIntegration.m
+++ b/Snapyr/Classes/SnapyrSnapyrIntegration.m
@@ -434,7 +434,7 @@ NSUInteger const kSnapyrBackgroundTaskInvalid = 0;
     } else {
 #ifdef DEBUG
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-        DLog(@"SnapyrSnapyrIntegration.batch: body is [%@]", jsonString);
+        DLog(@"SnapyrSnapyrIntegration.batch: body is:\n%@\n", jsonString);
 #endif
     }
     
@@ -470,7 +470,7 @@ NSUInteger const kSnapyrBackgroundTaskInvalid = 0;
 {
     NSError* dataParsingError = nil;
     NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    DLog(@"SnapyrSnapyrIntegration.processResponseData: response is [%@]", responseString);
+    DLog(@"SnapyrSnapyrIntegration.processResponseData: response is:\n%@\n", responseString);
     
     id dataObj = [NSJSONSerialization
                   JSONObjectWithData:data

--- a/Snapyr/Snapyr.h
+++ b/Snapyr/Snapyr.h
@@ -23,3 +23,4 @@ FOUNDATION_EXPORT const unsigned char SnapyrVersionString[];
 #import "SnapyrSDKUtils.h"
 #import "SnapyrWebhookIntegration.h"
 #import "SnapyrLogger.h"
+#import "SnapyrNotification.h"


### PR DESCRIPTION
Adds SDK methods that can be called in consumer's AppDelegate as one-liners, to handle various parts of push notification handling.

These methods can be called before the SDK is initialized, facilitating push notification callback handling in the React Native SDK (because in RN, the SDK initialization is done from JS, which will be ready later than early AppDelegate lifecycle, and possibly too late to catch a push response that triggered the app to open).

These methods fire internal notifications that can be listened to by any receiver within the app process, and are used by the React Native SDK. This maps roughly to the broadcasts and broadcast receivers we use with React Native on the Android side.

Example calls of these methods from the appropriate AppDelegate methods:

```objc
- (void)application:(UIApplication *)app didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
{
  // After successful push registration, this code decodes the device token and registers it with Snapyr. This is required to allow Snapyr campaigns to send push notifications to the device.
  [SnapyrSDK appRegisteredForRemoteNotificationsWithDeviceToken:deviceToken];
}

- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
  // This tells Snapyr that a notification successfully arrived on the device, and is required to allow your Snapyr campaigns to track the "received" rate for campaigns.
  [SnapyrSDK appDidReceiveRemoteNotification:userInfo];
  completionHandler(UIBackgroundFetchResultNewData);
}

- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
{
  // This tells Snapyr that a notification was tapped, and is required to allow your Snapyr campaigns to track the "clicked" rate for campaigns.
  // Snapyr will also attempt to open the deep link URL from the notification, if one was set on the push creative.
  [SnapyrSDK appDidReceiveNotificationResponse:response];
  // Do not remove the following line!
  completionHandler();
}

- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
{
  // This method is triggered if a notification is received while the app is in the foreground.
  // This tells Snapyr that a notification successfully arrived on the device, and is required to allow your Snapyr campaigns to track the "received" rate for campaigns.
  [SnapyrSDK appDidReceiveRemoteNotification:notification.request.content.userInfo];
  // Optional: by default, notifications received in the foreground are not displayed. If you would like to display the notification over the app, run the following line.
  completionHandler(UNNotificationPresentationOptionAlert);
}
```